### PR TITLE
scaffold: Flask base with CI and Render configuration

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}   # requerido para repos privados
+          token: ${{ secrets.CODECOV_TOKEN }}   # requerido si el repo es privado
           files: coverage.xml
           flags: unittests
           fail_ci_if_error: false

--- a/.render.yaml
+++ b/.render.yaml
@@ -1,0 +1,8 @@
+services:
+  - type: web
+    name: sgc-servidor
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn app.main:app
+    autoDeploy: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Proyecto-Codex
-Servidor Flask para Codex
-Primera configuración
+
+Base Flask + gunicorn. Despliegue en **Render** con Auto-Deploy.  
+CI con **pytest + coverage** y subida a **Codecov**.
 
 [![CI - Coverage](https://github.com/TU_USUARIO/TU_REPO/actions/workflows/ci-coverage.yml/badge.svg)](https://github.com/TU_USUARIO/TU_REPO/actions/workflows/ci-coverage.yml)
-
 [![codecov](https://codecov.io/gh/TU_USUARIO/TU_REPO/branch/main/graph/badge.svg)](https://app.codecov.io/gh/TU_USUARIO/TU_REPO)
+
+## Ejecutar local
+```bash
+pip install -r requirements.txt
+gunicorn -b 127.0.0.1:8000 app.main:app
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,9 @@
+from flask import Flask
+import os
+
+app = Flask(__name__)
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev-secret")
+
+@app.route("/")
+def home():
+    return "Hola desde Elyra + Render 🚀"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+gunicorn==22.0.0

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,2 @@
+def test_true():
+    assert True


### PR DESCRIPTION
## Summary
- add a simple Flask application with a default secret key and root endpoint response
- declare runtime dependencies, smoke test, and documentation for local usage and deployment
- configure GitHub Actions workflow for coverage reporting and optional Codecov upload, plus Render service config

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8c0fbdc4c83268910bca59819085e