### PR TITLE
fix: convertir app en paquete (añadir __init__.py)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,9 @@
 """Paquete de la aplicación Flask para Proyecto-Codex."""
 
-__all__ = ["__version__"]
+from __future__ import annotations
+
+from .main import create_app
+
+__all__ = ["create_app", "__version__"]
 
 __version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- re-export the factory function from the package initializer so the application can be imported as a package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8d4992a608326a0b1ec10cd9e8cec