### PR TITLE
Simplify app import in home test

### DIFF
--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,16 +1,8 @@
-"""Pruebas para el endpoint principal de la aplicación."""
-
-import importlib
-
-
-def get_app():
-    module = importlib.import_module("app.main")
-    return getattr(module, "app")
+from app.main import app
 
 
 def test_home_returns_text():
-    app = get_app()
     client = app.test_client()
-    response = client.get("/")
-    assert response.status_code == 200
-    assert b"Elyra + Render" in response.data
+    r = client.get("/")
+    assert r.status_code == 200
+    assert b"Elyra + Render" in r.data


### PR DESCRIPTION
## Summary
- simplify test setup by importing the Flask app directly in `tests/test_home.py`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8d4a2fd3c83269227aafd47b62937