### PR TITLE
ci: agregar configuración inicial de Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,24 @@
 coverage:
+  precision: 2
+  round: down
+  range: "50...90"
+
   status:
     project:
       default:
-        target: 80%   # exige al menos 80% cobertura global
-        threshold: 2% # permite variación del ±2%
+        target: 70%
+        threshold: 2%
+        base: auto
     patch:
       default:
-        target: auto
+        target: 60%
+        threshold: 1%
+
 comment:
-  layout: "diff, flags, files"
+  layout: "reach,diff,flags,files"
   behavior: default
+  require_changes: true
+
+ignore:
+  - "tests/"
+  - "migrations/"


### PR DESCRIPTION
## Summary
- reemplazar la configuración de Codecov para ajustar reglas de cobertura y comentarios

## Testing
- No se ejecutaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8d6a087888326b8c6721642fe575c