### PR TITLE
ci: configure pr and coverage workflows

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -3,15 +3,13 @@ name: CI - Coverage
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  test:
+  coverage:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,12 +53,10 @@ jobs:
           name: coverage-xml
           path: coverage.xml
 
-      # Subimos a Codecov SOLO en push (no en pull_request, porque no hay secrets en PR de fork)
-      - name: Upload to Codecov (push only)
-        if: github.event_name == 'push'
+      - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}   # requerido para repos privados
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           flags: unittests
           fail_ci_if_error: false

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (PR)
 
 on:
   pull_request:
@@ -15,10 +15,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install & test (PR safe)
+
+      - name: Install & test (PR-safe)
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt || true


### PR DESCRIPTION
## Summary
- replace the old pull request workflow with `ci-pr.yml` focused on PR-safe testing
- update the coverage workflow to run on pushes to `main` with caching and Codecov upload

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8db2dab808326b5e9a52e52623ab8