### PR TITLE
ci: enable coverage on push for public repo; remove Codecov token usage

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -2,15 +2,21 @@ name: CI - Coverage
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,9 +55,10 @@ jobs:
           path: coverage.xml
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
           flags: unittests
           fail_ci_if_error: false
           verbose: true
+          use_oidc: true

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Servidor Flask para Codex Primera configuración
 
 [![CI - Coverage](https://github.com/Mag0de0z2099/Proyecto-Codex/actions/workflows/ci-coverage.yml/badge.svg)](https://github.com/Mag0de0z2099/Proyecto-Codex/actions/workflows/ci-coverage.yml)
-[![codecov](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?token=00479470-3f7d-45a9-a6b9-abffb84f57db)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex)
+[![codecov](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex)
 [![Render](https://img.shields.io/website?url=https%3A%2F%2Fproyecto-codex.onrender.com&label=Render%20Deploy&style=flat-square)](https://proyecto-codex.onrender.com)


### PR DESCRIPTION
## Summary
- configure the coverage workflow to run on push and pull_request triggers
- enable Codecov uploads with OIDC instead of a repository token
- update the README badge to stop referencing the Codecov token

## Testing
- pytest --cov=app --cov-report=xml --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68c8e295bd088326942d25bf054da2e2