### PR TITLE
Add /health route for Render health checks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from .main import create_app
+from .main import app
 
-__all__ = ["create_app", "__version__"]
+__all__ = ["app", "__version__"]
 
 __version__ = "0.1.0"

--- a/app/main.py
+++ b/app/main.py
@@ -1,24 +1,15 @@
-"""Punto de entrada principal para la aplicación Flask."""
-
-from __future__ import annotations
-
 from flask import Flask
+import os
+
+app = Flask(__name__)
+app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev-secret")
 
 
-def create_app() -> Flask:
-    """Crea y configura una instancia de la aplicación Flask."""
-    app = Flask(__name__)
-
-    @app.get("/")
-    def home() -> str:
-        """Devuelve un texto de bienvenida simple."""
-        return "Elyra + Render"
-
-    return app
+@app.route("/")
+def home():
+    return "Hola desde Elyra + Render 🚀"
 
 
-app = create_app()
-
-
-if __name__ == "__main__":  # pragma: no cover - ejecución manual
-    app.run(debug=True)
+@app.route("/health")
+def health():
+    return "ok", 200

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -3,6 +3,13 @@ from app.main import app
 
 def test_home_returns_text():
     client = app.test_client()
-    r = client.get("/")
-    assert r.status_code == 200
-    assert b"Elyra + Render" in r.data
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Hola desde Elyra + Render 🚀" in response.get_data(as_text=True)
+
+
+def test_health_route_returns_ok():
+    client = app.test_client()
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "ok"


### PR DESCRIPTION
## Summary
- rewrite the Flask entrypoint to expose a health check endpoint and configure the secret key from the environment
- adjust the package init to re-export the app object
- update tests to reflect the new greeting and cover the /health endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8e7409cfc832691e951015635c214