### PR TITLE
Add Procfile for Gunicorn deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app.main:app --bind 0.0.0.0:$PORT


### PR DESCRIPTION
## Summary
- add a Procfile that starts the FastAPI app with gunicorn bound to the runtime port

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8e759e07c8326b8742184a42a412a