### PR TITLE
chore: configurar CORS, logs y errores básicos

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,8 +2,40 @@
 
 from __future__ import annotations
 
-from .main import app
+import logging
+from flask import Flask
 
-__all__ = ["app", "__version__"]
+from .config import get_config
+from .extensions import init_extensions
+from .errors import register_error_handlers
+from .blueprints.web import bp_web
+from .blueprints.api.v1 import bp_api_v1
+
+__all__ = ["create_app", "__version__"]
 
 __version__ = "0.1.0"
+
+
+def create_app(config_name: str | None = None) -> Flask:
+    """Crea y configura una instancia de :class:`~flask.Flask`."""
+    app = Flask(__name__)
+    app.config.from_object(get_config(config_name))
+
+    if not app.debug:
+        gunicorn_error_logger = logging.getLogger("gunicorn.error")
+        if gunicorn_error_logger.handlers:
+            app.logger.handlers = gunicorn_error_logger.handlers
+            app.logger.setLevel(gunicorn_error_logger.level)
+        else:  # pragma: no cover - fallback para entornos sin Gunicorn
+            handler = logging.StreamHandler()
+            handler.setLevel(logging.INFO)
+            app.logger.addHandler(handler)
+            app.logger.setLevel(logging.INFO)
+
+    init_extensions(app)
+
+    app.register_blueprint(bp_web)
+    app.register_blueprint(bp_api_v1, url_prefix="/api/v1")
+
+    register_error_handlers(app)
+    return app

--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -1,0 +1,5 @@
+"""Paquete que agrupa los blueprints de la aplicación."""
+
+from __future__ import annotations
+
+__all__ = ["api", "web"]

--- a/app/blueprints/api/__init__.py
+++ b/app/blueprints/api/__init__.py
@@ -1,0 +1,7 @@
+"""Blueprints relacionados con la API."""
+
+from __future__ import annotations
+
+from .v1 import bp_api_v1
+
+__all__ = ["bp_api_v1"]

--- a/app/blueprints/api/v1/__init__.py
+++ b/app/blueprints/api/v1/__init__.py
@@ -1,0 +1,13 @@
+"""Versión 1 de la API pública."""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response, jsonify
+
+bp_api_v1 = Blueprint("api_v1", __name__)
+
+
+@bp_api_v1.route("/ping")
+def ping() -> tuple[Response, int]:
+    """Devuelve un mensaje mínimo para verificar disponibilidad."""
+    return jsonify(message="pong"), 200

--- a/app/blueprints/web/__init__.py
+++ b/app/blueprints/web/__init__.py
@@ -1,0 +1,19 @@
+"""Blueprint con rutas públicas del sitio."""
+
+from __future__ import annotations
+
+from flask import Blueprint
+
+bp_web = Blueprint("web", __name__)
+
+
+@bp_web.route("/")
+def home() -> str:
+    """Página principal simple."""
+    return "Hola desde Elyra + Render 🚀"
+
+
+@bp_web.route("/health")
+def health() -> tuple[str, int]:
+    """Endpoint de salud para Render."""
+    return "ok", 200

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,45 @@
+"""Configuraciones para la aplicación Flask."""
+
+from __future__ import annotations
+
+import os
+from typing import Type
+
+
+class BaseConfig:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret")
+    ALLOWED_ORIGINS = os.environ.get("ALLOWED_ORIGINS", "*")
+    TESTING = False
+    DEBUG = False
+
+
+class DevelopmentConfig(BaseConfig):
+    DEBUG = True
+
+
+class TestingConfig(BaseConfig):
+    TESTING = True
+    DEBUG = True
+
+
+class ProductionConfig(BaseConfig):
+    DEBUG = False
+
+
+CONFIG_MAP: dict[str, Type[BaseConfig]] = {
+    "development": DevelopmentConfig,
+    "testing": TestingConfig,
+    "production": ProductionConfig,
+    "default": BaseConfig,
+}
+
+
+def get_config(config_name: str | None = None) -> Type[BaseConfig]:
+    """Obtiene una clase de configuración basada en el nombre o env."""
+    if config_name:
+        return CONFIG_MAP.get(config_name.lower(), BaseConfig)
+
+    env_name = os.environ.get("FLASK_ENV") or os.environ.get("APP_ENV") or os.environ.get("ENV")
+    if env_name:
+        return CONFIG_MAP.get(env_name.lower(), BaseConfig)
+    return BaseConfig

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,37 @@
+"""Registro de manejadores de error para la aplicación."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Flask, jsonify, request
+
+
+def _is_api_request() -> bool:
+    """Determina si la solicitud apunta a la API."""
+    path = request.path or ""
+    return path.startswith("/api/")
+
+
+def register_error_handlers(app: Flask) -> None:
+    """Registra manejadores simples que devuelven texto o JSON."""
+
+    @app.errorhandler(404)
+    def not_found(error: Exception) -> tuple[Any, int]:  # pragma: no cover - decorador
+        if app.debug:
+            return ("Not Found", 404)
+        if _is_api_request():
+            return jsonify(error="Not Found"), 404
+        return ("Not Found", 404)
+
+    @app.errorhandler(400)
+    def bad_request(error: Exception) -> tuple[Any, int]:  # pragma: no cover - decorador
+        if _is_api_request():
+            return jsonify(error="Bad Request"), 400
+        return ("Bad Request", 400)
+
+    @app.errorhandler(500)
+    def server_error(error: Exception) -> tuple[Any, int]:  # pragma: no cover - decorador
+        if _is_api_request():
+            return jsonify(error="Server Error"), 500
+        return ("Server Error", 500)

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,0 +1,12 @@
+"""Aplicaciones complementarias para la app Flask."""
+
+from __future__ import annotations
+
+from flask import Flask
+from flask_cors import CORS
+
+
+def init_extensions(app: Flask) -> None:
+    """Inicializa extensiones de terceros."""
+    origins = app.config.get("ALLOWED_ORIGINS", "*")
+    CORS(app, resources={r"/api/*": {"origins": origins}})

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,13 @@
+"""Punto de entrada para ejecutar la aplicación Flask."""
+
+from __future__ import annotations
+
 from flask import Flask
-import os
 
-app = Flask(__name__)
-app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev-secret")
+from . import create_app
 
-
-@app.route("/")
-def home():
-    return "Hola desde Elyra + Render 🚀"
+app: Flask = create_app()
 
 
-@app.route("/health")
-def health():
-    return "ok", 200
+if __name__ == "__main__":  # pragma: no cover - ejecución manual
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ Werkzeug==3.0.3
 # Testing
 pytest==8.3.3
 pytest-cov==5.0.0
+flask-cors==4.0.1
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- refactor the Flask factory to load configuration, extensions, blueprints and error handlers
- add basic web and API blueprints plus configuration, extensions and error modules
- enable CORS for `/api/*`, allow origins from the environment and document dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8ef759cdc8326a6e5b00454ccfb0f