### PR TITLE
feat: add admin blueprint with auth endpoints

### DIFF
--- a/app/blueprints/admin/__init__.py
+++ b/app/blueprints/admin/__init__.py
@@ -1,0 +1,11 @@
+"""Blueprint para el área administrativa del proyecto."""
+
+from __future__ import annotations
+
+from flask import Blueprint
+
+bp_admin = Blueprint("admin", __name__)
+
+from . import routes  # noqa: E402  (importa las rutas al registrar el blueprint)
+
+__all__ = ["bp_admin"]

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -1,0 +1,36 @@
+"""Rutas para la zona administrativa."""
+
+from __future__ import annotations
+
+from flask import current_app, jsonify, request, session
+
+from . import bp_admin
+
+
+@bp_admin.get("/")
+def admin_home():
+    """Zona protegida que requiere sesión de administrador."""
+
+    if session.get("admin"):
+        return jsonify(area="admin", status="ok"), 200
+    return jsonify(error="unauthorized"), 401
+
+
+@bp_admin.post("/login")
+def admin_login():
+    """Autenticar al usuario administrador mediante una contraseña simple."""
+
+    data = request.get_json(silent=True) or {}
+    password = data.get("password")
+    if password and password == current_app.config.get("ADMIN_PASSWORD", "admin"):
+        session["admin"] = True
+        return jsonify(ok=True), 200
+    return jsonify(ok=False, error="bad credentials"), 401
+
+
+@bp_admin.post("/logout")
+def admin_logout():
+    """Cerrar la sesión de administrador."""
+
+    session.pop("admin", None)
+    return jsonify(ok=True), 200

--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,10 @@ class BaseConfig:
     """Configuración base compartida."""
 
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret")
+    ALLOWED_ORIGINS = os.environ.get("ALLOWED_ORIGINS", "*")
+    ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "admin")
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SAMESITE = "Lax"
 
 
 class DevConfig(BaseConfig):

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,39 @@
+"""Manejadores de errores personalizados."""
+
+from __future__ import annotations
+
+from flask import Flask, jsonify, request
+from werkzeug.exceptions import HTTPException
+
+
+def _wants_json_response() -> bool:
+    if request.path.startswith("/api/"):
+        return True
+    best = request.accept_mimetypes.best_match(["application/json", "text/html"])
+    if not best:
+        return False
+    json_q = request.accept_mimetypes["application/json"]
+    html_q = request.accept_mimetypes["text/html"]
+    return best == "application/json" and json_q >= html_q
+
+
+def register_error_handlers(app: Flask) -> None:
+    """Registrar manejadores de errores comunes."""
+
+    def handle_http_error(error: HTTPException):
+        if _wants_json_response():
+            response = jsonify(error=getattr(error, "description", "error"))
+            response.status_code = error.code or 500
+            return response
+        return error
+
+    def handle_unexpected(error: Exception):
+        app.logger.exception("Unhandled exception", exc_info=error)
+        if _wants_json_response():
+            response = jsonify(error="internal server error")
+            response.status_code = 500
+            return response
+        raise error
+
+    app.register_error_handler(HTTPException, handle_http_error)
+    app.register_error_handler(Exception, handle_unexpected)

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,0 +1,63 @@
+"""Inicialización de extensiones y hooks personalizados."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+from flask import Flask, request
+
+
+def _coerce_origins(raw: object) -> Sequence[str]:
+    if raw is None:
+        return ("*",)
+    if isinstance(raw, str):
+        parts = [item.strip() for item in raw.split(",")]
+        return tuple(part for part in parts if part)
+    if isinstance(raw, Iterable):
+        cleaned: list[str] = []
+        for item in raw:
+            text = str(item).strip()
+            if text:
+                cleaned.append(text)
+        return tuple(cleaned) or ("*",)
+    return (str(raw),)
+
+
+def init_extensions(app: Flask) -> None:
+    """Configurar extensiones y middleware para la aplicación."""
+
+    origins = _coerce_origins(app.config.get("ALLOWED_ORIGINS", "*"))
+
+    @app.after_request
+    def apply_cors_headers(response):
+        origin = request.headers.get("Origin")
+        allow_origin = "*"
+        if origins and "*" not in origins:
+            if origin and origin in origins:
+                allow_origin = origin
+            else:
+                allow_origin = origins[0]
+        response.headers.setdefault("Access-Control-Allow-Origin", allow_origin)
+        response.headers.setdefault(
+            "Access-Control-Allow-Headers", "Content-Type, Authorization"
+        )
+        response.headers.setdefault(
+            "Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+        )
+        response.headers.setdefault("Access-Control-Allow-Credentials", "true")
+        if response.headers.get("Access-Control-Allow-Origin") != "*":
+            vary_header = response.headers.get("Vary")
+            if vary_header:
+                vary_values = {value.strip() for value in vary_header.split(",") if value.strip()}
+                if "Origin" not in vary_values:
+                    vary_values.add("Origin")
+                    response.headers["Vary"] = ", ".join(sorted(vary_values))
+            else:
+                response.headers["Vary"] = "Origin"
+        return response
+
+    @app.before_request
+    def handle_preflight():
+        if request.method == "OPTIONS":
+            return app.make_default_options_response()
+        return None

--- a/tests/admin/test_admin_auth.py
+++ b/tests/admin/test_admin_auth.py
@@ -1,0 +1,52 @@
+"""Pruebas para la autenticación del área administrativa."""
+
+from __future__ import annotations
+
+from app import create_app
+
+
+def test_admin_requires_auth() -> None:
+    app = create_app("test")
+    client = app.test_client()
+
+    response = client.get("/admin/")
+
+    assert response.status_code == 401
+    payload = response.get_json()
+    assert payload == {"error": "unauthorized"}
+
+
+def test_admin_login_ok_and_access() -> None:
+    app = create_app("test")
+    client = app.test_client()
+
+    response = client.post("/admin/login", json={"password": "admin"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True}
+
+    response = client.get("/admin/")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"area": "admin", "status": "ok"}
+
+    response = client.post("/admin/logout")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True}
+
+    response = client.get("/admin/")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "unauthorized"}
+
+
+def test_admin_login_wrong_password() -> None:
+    app = create_app("test")
+    client = app.test_client()
+
+    response = client.post("/admin/login", json={"password": "wrong"})
+
+    assert response.status_code == 401
+    payload = response.get_json()
+    assert payload == {"ok": False, "error": "bad credentials"}


### PR DESCRIPTION
## Summary
- add an admin blueprint with login, logout, and a protected home endpoint
- expose configuration for admin password and default session/CORS settings
- initialize CORS and error handling hooks and register the admin blueprint
- cover the admin authentication flow with new pytest cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8f5bf77f08326a6e81caafe3dd167