### PR TITLE
feat(admin): add minimal admin UI

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from flask import current_app, jsonify, request, session
+from flask import current_app, jsonify, render_template, request, session
 
 from . import bp_admin
 
@@ -34,3 +34,10 @@ def admin_logout():
 
     session.pop("admin", None)
     return jsonify(ok=True), 200
+
+
+@bp_admin.get("/ui")
+def admin_ui():
+    """Servir una interfaz mínima para gestionar el login del administrador."""
+
+    return render_template("admin_ui.html")

--- a/app/templates/admin_ui.html
+++ b/app/templates/admin_ui.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Admin UI</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font-family: system-ui, Arial, sans-serif; margin: 2rem; }
+    .card { max-width: 520px; padding: 1rem 1.25rem; border: 1px solid #8883; border-radius: 12px; }
+    label { display:block; margin:.5rem 0 .25rem; font-weight:600; }
+    input { width:100%; padding:.6rem .7rem; border:1px solid #8884; border-radius:10px; }
+    button { padding:.6rem .9rem; border:0; border-radius:10px; cursor:pointer; font-weight:600; }
+    .row { display:flex; gap:.5rem; margin-top:.75rem; }
+    .ok { color: #0a7; font-weight:700; }
+    .err{ color: #d33; font-weight:700; }
+    .muted{ opacity:.7; font-size:.9rem; }
+    .pill{ display:inline-block; padding:.25rem .6rem; border-radius:999px; font-size:.8rem; }
+    .pill-ok{ background:#0a74; color:#0a7; }
+    .pill-bad{ background:#d334; color:#d33; }
+    pre{ background:#0002; padding:.75rem; border-radius:10px; overflow:auto; }
+  </style>
+</head>
+<body>
+  <h1>Panel Admin (demo)</h1>
+  <p class="muted">Esta UI usa <code>fetch()</code> hacia <code>/admin/*</code> en el **mismo origen** para mantener la cookie de sesión.</p>
+
+  <div class="card">
+    <div id="status"></div>
+
+    <div id="loginBox">
+      <label for="pwd">Contraseña</label>
+      <input id="pwd" type="password" placeholder="Tu ADMIN_PASSWORD" />
+      <div class="row">
+        <button id="btnLogin">Iniciar sesión</button>
+        <button id="btnCheck">Comprobar acceso</button>
+      </div>
+    </div>
+
+    <div id="secureBox" style="display:none; margin-top:1rem;">
+      <div>Área protegida: <span class="pill pill-ok">/admin/</span></div>
+      <pre id="secureOut"></pre>
+      <div class="row">
+        <button id="btnLoad">Cargar /admin/</button>
+        <button id="btnLogout">Cerrar sesión</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const $ = s => document.querySelector(s);
+    const status = $("#status");
+    const loginBox = $("#loginBox");
+    const secureBox = $("#secureBox");
+    const out = $("#secureOut");
+
+    const show = (el, on=true)=> el.style.display = on ? "" : "none";
+    const setStatus = (ok, msg) => {
+      status.innerHTML = ok
+        ? `<p class="ok">✅ ${msg}</p>`
+        : `<p class="err">⚠️ ${msg}</p>`;
+    };
+
+    async function checkAccess() {
+      try {
+        const r = await fetch("/admin/", { credentials: "include" });
+        if (r.ok) {
+          const data = await r.json();
+          setStatus(true, `Conectado como admin. area=${data.area}`);
+          show(loginBox, false);
+          show(secureBox, true);
+          out.textContent = JSON.stringify(data, null, 2);
+        } else if (r.status === 401) {
+          setStatus(false, "No autenticado. Inicia sesión.");
+          show(loginBox, true);
+          show(secureBox, false);
+        } else {
+          setStatus(false, `Error ${r.status} al consultar /admin/`);
+        }
+      } catch (e) {
+        setStatus(false, "Error de red verificando acceso.");
+      }
+    }
+
+    async function doLogin() {
+      const pwd = $("#pwd").value.trim();
+      if (!pwd) { setStatus(false, "Ingresa la contraseña"); return; }
+      try {
+        const r = await fetch("/admin/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ password: pwd })
+        });
+        const data = await r.json().catch(() => ({}));
+        if (r.ok && data.ok) {
+          setStatus(true, "Inicio de sesión correcto");
+          await checkAccess();
+        } else {
+          setStatus(false, data?.error || "Credenciales inválidas");
+        }
+      } catch {
+        setStatus(false, "Error de red al iniciar sesión");
+      }
+    }
+
+    async function loadSecure() {
+      try {
+        const r = await fetch("/admin/", { credentials: "include" });
+        const txt = await r.text();
+        out.textContent = txt;
+      } catch {
+        out.textContent = "Error de red";
+      }
+    }
+
+    async function doLogout() {
+      try {
+        const r = await fetch("/admin/logout", { method: "POST", credentials: "include" });
+        if (r.ok) {
+          setStatus(true, "Sesión cerrada");
+        }
+      } catch {}
+      show(loginBox, true);
+      show(secureBox, false);
+    }
+
+    $("#btnLogin").addEventListener("click", doLogin);
+    $("#btnCheck").addEventListener("click", checkAccess);
+    $("#btnLoad").addEventListener("click", loadSecure);
+    $("#btnLogout").addEventListener("click", doLogout);
+
+    // Al cargar la página, verificar si ya hay sesión
+    checkAccess();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an `/admin/ui` route that serves a minimal admin interface
- provide an HTML+JS template that handles login, logout, and session checks via fetch

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c90d0434c48326be154bbdd06b6a2e