### PR TITLE
Add DATA_DIR storage utilities and admin write test endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from .blueprints.web import bp_web
 from .config import get_config
 from .errors import register_error_handlers
 from .extensions import init_extensions
+from .storage import ensure_dirs
 
 __all__ = ["create_app", "__version__"]
 
@@ -31,6 +32,9 @@ def create_app(config_name: str | None = None) -> Flask:
             app.logger.setLevel(gunicorn_error_logger.level)
 
     init_extensions(app)
+
+    # Asegurar directorios persistentes (DATA_DIR)
+    ensure_dirs(app)
 
     app.register_blueprint(bp_web)
     app.register_blueprint(bp_api_v1, url_prefix="/api/v1")

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from flask import current_app, jsonify, render_template, request, session
+from flask import current_app as app, jsonify, render_template, request, session
 
 from . import bp_admin
+from app.storage import join
 
 
 @bp_admin.get("/")
@@ -22,7 +23,7 @@ def admin_login():
 
     data = request.get_json(silent=True) or {}
     password = data.get("password")
-    if password and password == current_app.config.get("ADMIN_PASSWORD", "admin"):
+    if password and password == app.config.get("ADMIN_PASSWORD", "admin"):
         session["admin"] = True
         return jsonify(ok=True), 200
     return jsonify(ok=False, error="bad credentials"), 401
@@ -34,6 +35,16 @@ def admin_logout():
 
     session.pop("admin", None)
     return jsonify(ok=True), 200
+
+
+@bp_admin.post("/write-test")
+def write_test():
+    """Crear o sobrescribir un archivo de prueba en el directorio de cargas."""
+
+    path = join(app, "uploads", "prueba.txt")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("archivo creado OK")
+    return jsonify(ok=True, path=path), 200
 
 
 @bp_admin.get("/ui")

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,23 @@
+import os
+
+
+def _clean(p: str) -> str:
+    return os.path.abspath(os.path.expanduser(p))
+
+
+def get_data_dir(app) -> str:
+    base = app.config.get("DATA_DIR") or os.environ.get("DATA_DIR") or "./data"
+    return _clean(base)
+
+
+def ensure_dirs(app) -> str:
+    base = get_data_dir(app)
+    # Crea subdirectorios típicos
+    for sub in ("uploads", "db"):
+        os.makedirs(os.path.join(base, sub), exist_ok=True)
+    app.logger.info("DATA_DIR=%s", base)
+    return base
+
+
+def join(app, *parts) -> str:
+    return os.path.join(get_data_dir(app), *parts)


### PR DESCRIPTION
## Summary
- add a storage helper module to resolve the data directory and common subfolders
- ensure the Flask factory creates persistent storage folders on startup
- expose an admin testing endpoint that writes a file into the uploads directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c91b6576d483269154c1ea43483490