### PR TITLE
Add SQLite persistence and todo CRUD API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ db.sqlite3-journal
 
 # Flask stuff:
 instance/
+data/
 .webassets-cache
 
 # Scrapy stuff:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ from .blueprints.admin import bp_admin
 from .blueprints.api.v1 import bp_api_v1
 from .blueprints.web import bp_web
 from .config import get_config
+from .db import db, init_db
 from .errors import register_error_handlers
 from .extensions import init_extensions
 from .storage import ensure_dirs
@@ -35,6 +36,12 @@ def create_app(config_name: str | None = None) -> Flask:
 
     # Asegurar directorios persistentes (DATA_DIR)
     ensure_dirs(app)
+
+    # Base de datos
+    init_db(app)
+    with app.app_context():
+        from . import models  # noqa: F401  (asegura el registro de modelos)
+        db.create_all()
 
     app.register_blueprint(bp_web)
     app.register_blueprint(bp_api_v1, url_prefix="/api/v1")

--- a/app/blueprints/api/v1/__init__.py
+++ b/app/blueprints/api/v1/__init__.py
@@ -7,5 +7,6 @@ from flask import Blueprint
 bp_api_v1 = Blueprint("api_v1", __name__)
 
 from . import routes  # noqa: E402  (importa las rutas al registrar el blueprint)
+from . import todos  # noqa: E402  (importa endpoints CRUD)
 
 __all__ = ["bp_api_v1"]

--- a/app/blueprints/api/v1/todos.py
+++ b/app/blueprints/api/v1/todos.py
@@ -1,0 +1,66 @@
+"""Endpoints CRUD para el modelo ``Todo``."""
+
+from __future__ import annotations
+
+from flask import jsonify, request
+
+from ....db import db
+from ....models import Todo
+from . import bp_api_v1
+
+
+@bp_api_v1.get("/todos")
+def list_todos():
+    """Listar todas las tareas ordenadas por creación descendente."""
+
+    items = Todo.query.order_by(Todo.id.desc()).all()
+    return jsonify([item.to_dict() for item in items])
+
+
+@bp_api_v1.post("/todos")
+def create_todo():
+    """Crear una nueva tarea."""
+
+    data = request.get_json(silent=True) or {}
+    title = (data.get("title") or "").strip()
+    if not title:
+        return jsonify(error="title required"), 400
+    todo = Todo(title=title, done=bool(data.get("done", False)))
+    db.session.add(todo)
+    db.session.commit()
+    return jsonify(todo.to_dict()), 201
+
+
+@bp_api_v1.get("/todos/<int:todo_id>")
+def get_todo(todo_id: int):
+    """Obtener el detalle de una tarea."""
+
+    todo = Todo.query.get_or_404(todo_id)
+    return jsonify(todo.to_dict())
+
+
+@bp_api_v1.patch("/todos/<int:todo_id>")
+def update_todo(todo_id: int):
+    """Actualizar parcialmente una tarea."""
+
+    todo = Todo.query.get_or_404(todo_id)
+    data = request.get_json(silent=True) or {}
+    if "title" in data:
+        title = (data.get("title") or "").strip()
+        if not title:
+            return jsonify(error="title required"), 400
+        todo.title = title
+    if "done" in data:
+        todo.done = bool(data.get("done"))
+    db.session.commit()
+    return jsonify(todo.to_dict())
+
+
+@bp_api_v1.delete("/todos/<int:todo_id>")
+def delete_todo(todo_id: int):
+    """Eliminar una tarea."""
+
+    todo = Todo.query.get_or_404(todo_id)
+    db.session.delete(todo)
+    db.session.commit()
+    return jsonify(ok=True)

--- a/app/config.py
+++ b/app/config.py
@@ -12,7 +12,7 @@ class BaseConfig:
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret")
     ALLOWED_ORIGINS = os.environ.get("ALLOWED_ORIGINS", "*")
     ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "admin")
-    DATA_DIR = os.environ.get("DATA_DIR", "./data")
+    DATA_DIR = os.path.abspath(os.environ.get("DATA_DIR", "./data"))
     SQLITE_PATH = os.path.join(DATA_DIR, "db", "app.db")
     SQLALCHEMY_DATABASE_URI = f"sqlite:///{SQLITE_PATH}"
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,15 @@
+"""Extensión de base de datos con SQLAlchemy."""
+
+from __future__ import annotations
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+def init_db(app: Flask) -> None:
+    """Inicializar la instancia de :class:`~flask_sqlalchemy.SQLAlchemy`."""
+
+    db.init_app(app)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,28 @@
+"""Modelos de base de datos de la aplicación."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from .db import db
+
+
+class Todo(db.Model):
+    """Modelo sencillo para tareas pendientes."""
+
+    __tablename__ = "todos"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    done = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    def to_dict(self) -> dict[str, object]:
+        """Representar la tarea como diccionario serializable."""
+
+        return {
+            "id": self.id,
+            "title": self.title,
+            "done": self.done,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ Werkzeug==3.0.3
 # Testing
 pytest==8.3.3
 pytest-cov==5.0.0
+Flask-SQLAlchemy==3.1.1
+SQLAlchemy==2.0.32


### PR DESCRIPTION
## Summary
- configure the app to initialize SQLAlchemy with a persistent SQLite database under DATA_DIR
- add a Todo model plus CRUD endpoints under /api/v1/todos
- add the required dependencies and ignore the generated data directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c92782eb748326b1416b8dd3c348ed