### PR TITLE
chore: add manage.py with db-upgrade command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,20 @@
+import click
+from flask_migrate import upgrade
+from app.main import app  # importa tu app ya inicializada con Migrate
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command("db-upgrade")
+def db_upgrade():
+    """Aplica las migraciones de Alembic."""
+    with app.app_context():
+        upgrade()
+        click.echo("DB upgraded successfully")
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- add a `manage.py` CLI that exposes a `db-upgrade` command for running Alembic migrations within the application context

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68c9389731508326b3222c095d6eb4e6