### PR TITLE
Add smoke and todos API CRUD tests

### DIFF
--- a/tests/test_api_todos.py
+++ b/tests/test_api_todos.py
@@ -1,0 +1,26 @@
+"""Basic CRUD coverage tests for the todos API."""
+
+from __future__ import annotations
+
+from app import create_app
+from app.db import db
+
+
+def test_todos_crud(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    app = create_app("test")
+    with app.app_context():
+        db.create_all()
+    client = app.test_client()
+    response = client.get("/api/v1/todos")
+    assert response.status_code == 200
+    response = client.post("/api/v1/todos", json={"title": "test todo"})
+    assert response.status_code in (200, 201)
+    todo = response.get_json()
+    todo_id = todo.get("id")
+    response = client.get("/api/v1/todos")
+    assert response.status_code == 200
+    assert any(t.get("id") == todo_id for t in response.get_json())
+    with app.app_context():
+        db.drop_all()
+        db.session.remove()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,12 @@
-def test_true():
-    """Prueba mínima para validar que pytest funciona."""
-    assert True
+"""Smoke tests for the Flask application."""
+
+from app import create_app
+
+
+def test_home_ok(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    app = create_app("test")
+    client = app.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Hola" in response.data or response.is_json or response.status_code == 200


### PR DESCRIPTION
## Summary
- add a smoke test that builds the app with the test configuration
- add an API test that exercises creating and fetching todos and manages the temporary database schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c943a3de248326ba0412a8212b3c91