### PR TITLE
Add smoke and admin flow tests for Flask app

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,41 @@
 
 from __future__ import annotations
 
+import importlib
+import os
 import sys
 from pathlib import Path
+
+import pytest
+
 
 # Aseguramos que la raíz del proyecto esté en sys.path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Crear un cliente de pruebas con configuración mínima."""
+
+    monkeypatch.setenv("ADMIN_PASSWORD", "pass123")
+    monkeypatch.setenv("SECRET_KEY", "tests-secret")
+
+    module_name = "app.main"
+    if module_name in sys.modules:
+        module = importlib.reload(sys.modules[module_name])
+    else:
+        module = importlib.import_module(module_name)
+    # Garantizar que la app se refresque tras modificar entornos.
+    module = importlib.reload(module)
+
+    app = getattr(module, "app")
+    app.config.update(
+        TESTING=True,
+        ADMIN_PASSWORD=os.environ.get("ADMIN_PASSWORD", "admin"),
+        SECRET_KEY=os.environ.get("SECRET_KEY", app.config.get("SECRET_KEY")),
+    )
+
+    with app.test_client() as test_client:
+        yield test_client

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,17 @@
+def test_admin_login_and_logout_flow(client):
+    r = client.get("/admin/")
+    assert r.status_code in (401, 403, 200)
+
+    r = client.post("/admin/login", json={"password": "pass123"})
+    assert r.status_code in (200, 204)
+
+    r = client.get("/admin/")
+    assert r.status_code == 200
+    data = r.get_json() or {}
+    assert data.get("area") == "admin"
+
+    r = client.post("/admin/logout")
+    assert r.status_code in (200, 204)
+
+    r = client.get("/admin/")
+    assert r.status_code in (401, 403, 200)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,12 +1,5 @@
-"""Smoke tests for the Flask application."""
-
-from app import create_app
-
-
-def test_home_ok(tmp_path, monkeypatch):
-    monkeypatch.setenv("DATA_DIR", str(tmp_path))
-    app = create_app("test")
-    client = app.test_client()
-    response = client.get("/")
-    assert response.status_code == 200
-    assert b"Hola" in response.data or response.is_json or response.status_code == 200
+def test_home_ok(client):
+    r = client.get("/")
+    assert r.status_code == 200
+    body = (r.data or b"").decode("utf-8").lower()
+    assert "hola" in body or r.is_json or r.status_code == 200


### PR DESCRIPTION
## Summary
- provide a pytest client fixture that refreshes the Flask app with test-specific environment overrides
- add smoke and admin session flow tests that exercise the WSGI entrypoint
- configure pytest defaults for quiet execution and root test path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c945e6d3688326b2d5820cf245f74d