### PR TITLE
feat: add v1 users API and tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from flask import Flask
 
+from .api.v1 import bp as bp_api_v1
 from .config import get_config
 from .db import db
 from .migrate_ext import init_migrations
@@ -32,5 +33,6 @@ def create_app(config_name: str | None = None) -> Flask:
 
     # Blueprints
     app.register_blueprint(bp_web)
+    app.register_blueprint(bp_api_v1, url_prefix="/api/v1")
 
     return app

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+from flask import Blueprint
+
+bp_api = Blueprint("api", __name__)

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+from flask import Blueprint
+
+bp = Blueprint("api_v1", __name__)
+
+from . import users  # noqa: E402,F401

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from flask import request, jsonify
+from werkzeug.exceptions import BadRequest, NotFound
+
+from ...db import db
+from ...models.user import User
+from . import bp
+
+
+def _validate_email(email: str) -> None:
+    if not email or "@" not in email:
+        raise BadRequest("email is required and must contain '@'.")
+
+
+def _parse_pagination() -> tuple[int, int]:
+    try:
+        page = int(request.args.get("page", 1))
+        per_page = min(100, int(request.args.get("per_page", 20)))
+    except ValueError:
+        raise BadRequest("page and per_page must be integers.")
+    if page < 1 or per_page < 1:
+        raise BadRequest("page and per_page must be positive.")
+    return page, per_page
+
+
+@bp.get("/users")
+def list_users():
+    page, per_page = _parse_pagination()
+    q = User.query.paginate(page=page, per_page=per_page, error_out=False)
+    return jsonify(
+        {
+            "items": [u.to_dict() for u in q.items],
+            "page": q.page,
+            "per_page": q.per_page,
+            "total": q.total,
+        }
+    )
+
+
+@bp.post("/users")
+def create_user():
+    data = request.get_json(silent=True) or {}
+    email = (data.get("email") or "").strip()
+    _validate_email(email)
+
+    if User.query.filter_by(email=email).first() is not None:
+        raise BadRequest("email already exists.")
+
+    u = User(email=email)
+    db.session.add(u)
+    db.session.commit()
+    return jsonify(u.to_dict()), 201
+
+
+@bp.get("/users/<int:user_id>")
+def get_user(user_id: int):
+    u = User.query.get(user_id)
+    if not u:
+        raise NotFound("user not found")
+    return jsonify(u.to_dict())
+
+
+@bp.put("/users/<int:user_id>")
+def update_user(user_id: int):
+    u = User.query.get(user_id)
+    if not u:
+        raise NotFound("user not found")
+
+    data = request.get_json(silent=True) or {}
+    email = (data.get("email") or "").strip()
+    _validate_email(email)
+
+    if User.query.filter(User.id != user_id, User.email == email).first():
+        raise BadRequest("email already exists.")
+
+    u.email = email
+    db.session.commit()
+    return jsonify(u.to_dict())
+
+
+@bp.delete("/users/<int:user_id>")
+def delete_user(user_id: int):
+    u = User.query.get(user_id)
+    if not u:
+        raise NotFound("user not found")
+
+    db.session.delete(u)
+    db.session.commit()
+    return "", 204

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 from datetime import datetime
 from ..db import db
 
+
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(255), unique=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "email": self.email,
+            "created_at": self.created_at.isoformat() + "Z",
+        }
 
     def __repr__(self) -> str:
         return f"<User {self.email}>"

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+import json
+import pytest
+
+from app import create_app
+from app.db import db as _db
+
+
+@pytest.fixture()
+def app():
+    app = create_app("dev")  # usa DevConfig
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite://",  # en memoria
+    )
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_create_and_get_user(client):
+    # create
+    rv = client.post(
+        "/api/v1/users",
+        data=json.dumps({"email": "alice@example.com"}),
+        content_type="application/json",
+    )
+    assert rv.status_code == 201
+    data = rv.get_json()
+    assert data["email"] == "alice@example.com"
+    user_id = data["id"]
+
+    # get
+    rv = client.get(f"/api/v1/users/{user_id}")
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["id"] == user_id
+
+
+def test_list_users(client):
+    # seed
+    for e in ["a@a.com", "b@b.com", "c@c.com"]:
+        client.post("/api/v1/users", json={"email": e})
+
+    rv = client.get("/api/v1/users?page=1&per_page=2")
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["page"] == 1
+    assert data["per_page"] == 2
+    assert data["total"] == 3
+    assert len(data["items"]) == 2
+
+
+def test_update_user(client):
+    rv = client.post("/api/v1/users", json={"email": "x@x.com"})
+    user_id = rv.get_json()["id"]
+
+    rv = client.put(f"/api/v1/users/{user_id}", json={"email": "y@y.com"})
+    assert rv.status_code == 200
+    assert rv.get_json()["email"] == "y@y.com"
+
+
+def test_delete_user(client):
+    rv = client.post("/api/v1/users", json={"email": "z@z.com"})
+    user_id = rv.get_json()["id"]
+
+    rv = client.delete(f"/api/v1/users/{user_id}")
+    assert rv.status_code == 204
+
+    rv = client.get(f"/api/v1/users/{user_id}")
+    assert rv.status_code == 404
+
+
+def test_validation(client):
+    rv = client.post("/api/v1/users", json={"email": "invalid"})
+    assert rv.status_code == 400


### PR DESCRIPTION
## Summary
- add a versioned API blueprint with CRUD routes for users
- register the API blueprint in the app factory and add serialization helpers to the User model
- cover the new endpoints with pytest fixtures and tests

## Testing
- pytest tests/test_api_users.py

------
https://chatgpt.com/codex/tasks/task_e_68c9bc15e65c832692725527d755fb54