### PR TITLE
Add admin authentication and basic API endpoints

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from flask import Flask
 
+from .admin import bp as bp_admin
 from .api.v1 import bp as bp_api_v1
 from .config import get_config
 from .db import db
@@ -33,6 +34,7 @@ def create_app(config_name: str | None = None) -> Flask:
 
     # Blueprints
     app.register_blueprint(bp_web)
+    app.register_blueprint(bp_admin)
     app.register_blueprint(bp_api_v1, url_prefix="/api/v1")
 
     return app

--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -1,0 +1,43 @@
+"""Blueprint sencilla para el área administrativa."""
+
+from __future__ import annotations
+
+from flask import Blueprint, current_app, jsonify, request, session
+
+
+SESSION_KEY = "admin_authenticated"
+
+
+bp = Blueprint("admin", __name__, url_prefix="/admin")
+
+
+def _is_authenticated() -> bool:
+    return session.get(SESSION_KEY) is True
+
+
+def _require_password() -> str:
+    return current_app.config.get("ADMIN_PASSWORD", "admin")
+
+
+@bp.get("/", strict_slashes=False)
+def admin_index():
+    if not _is_authenticated():
+        return jsonify({"error": "unauthorized"}), 401
+    return jsonify({"area": "admin", "status": "ok"})
+
+
+@bp.post("/login")
+def admin_login():
+    payload = request.get_json(silent=True) or {}
+    password = payload.get("password")
+    if password == _require_password():
+        session[SESSION_KEY] = True
+        return jsonify({"ok": True})
+    session.pop(SESSION_KEY, None)
+    return jsonify({"ok": False, "error": "bad credentials"}), 401
+
+
+@bp.post("/logout")
+def admin_logout():
+    session.pop(SESSION_KEY, None)
+    return jsonify({"ok": True})

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -3,4 +3,4 @@ from flask import Blueprint
 
 bp = Blueprint("api_v1", __name__)
 
-from . import users  # noqa: E402,F401
+from . import ping, todos, users  # noqa: E402,F401

--- a/app/api/v1/ping.py
+++ b/app/api/v1/ping.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from flask import jsonify
+
+from . import bp
+
+
+@bp.get("/ping")
+def ping():
+    return jsonify({"ok": True, "version": "v1"})

--- a/app/api/v1/todos.py
+++ b/app/api/v1/todos.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from flask import jsonify, request
+from werkzeug.exceptions import BadRequest
+
+from ...db import db
+from ...models.todo import Todo
+from . import bp
+
+
+def _parse_payload() -> dict[str, object]:
+    payload = request.get_json(silent=True)
+    if payload is None:
+        raise BadRequest("JSON body required.")
+    if not isinstance(payload, dict):
+        raise BadRequest("JSON object expected.")
+    return payload
+
+
+@bp.get("/todos")
+def list_todos():
+    todos = Todo.query.order_by(Todo.id.asc()).all()
+    return jsonify([todo.to_dict() for todo in todos])
+
+
+@bp.post("/todos")
+def create_todo():
+    payload = _parse_payload()
+    title = str(payload.get("title") or "").strip()
+    if not title:
+        raise BadRequest("title is required")
+
+    todo = Todo(title=title)
+    db.session.add(todo)
+    db.session.commit()
+    return jsonify(todo.to_dict()), 201

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,2 +1,3 @@
 # Importa aquí tus modelos para que Alembic los detecte
+from .todo import Todo  # noqa: F401
 from .user import User  # noqa: F401

--- a/app/models/todo.py
+++ b/app/models/todo.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.sql import expression
+
+from ..db import db
+
+
+class Todo(db.Model):
+    __tablename__ = "todos"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(255), nullable=False)
+    completed = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        server_default=expression.false(),
+    )
+    created_at = db.Column(db.DateTime, nullable=False, server_default=func.now())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "completed": self.completed,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -6,3 +6,8 @@ bp = Blueprint("web", __name__)
 @bp.route("/")
 def index():
     return "Hola desde Elyra + Render 🚀"
+
+
+@bp.route("/health")
+def health():
+    return "ok"


### PR DESCRIPTION
## Summary
- add admin blueprint with session-based authentication endpoints
- expose health, ping, and todos routes required by tests
- extend configuration with testing profile and todo model

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9ccb6ea648326b5638a8597f84485