### PR TITLE
Configure testing setup to use in-memory SQLite

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,6 +18,9 @@ def create_app(config_name: str | None = None) -> Flask:
     app = Flask(__name__)
     app.config.from_object(get_config(config_name))
 
+    # Directorios persistentes (DATA_DIR, instance/, etc.)
+    ensure_dirs(app)
+
     # Log de Gunicorn en producción (Render)
     if not app.debug:
         gunicorn_error_logger = logging.getLogger("gunicorn.error")
@@ -28,9 +31,6 @@ def create_app(config_name: str | None = None) -> Flask:
     # DB
     db.init_app(app)
     init_migrations(app, db)
-
-    # Directorios persistentes (DATA_DIR, etc.)
-    ensure_dirs(app)
 
     # Blueprints
     app.register_blueprint(bp_web)

--- a/app/config.py
+++ b/app/config.py
@@ -28,6 +28,7 @@ class TestingConfig(BaseConfig):
     TESTING = True
     DEBUG = False
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {"connect_args": {"check_same_thread": False}}
 
 
 CONFIG_MAP: dict[str, type[BaseConfig]] = {

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -2,9 +2,21 @@ from __future__ import annotations
 from pathlib import Path
 from flask import Flask
 
+
 def ensure_dirs(app: Flask) -> None:
-    data_dir: Path = app.config["DATA_DIR"]
-    uploads = data_dir / "uploads"
-    logs = data_dir / "logs"
-    for p in (data_dir, uploads, logs):
-        p.mkdir(parents=True, exist_ok=True)
+    data_dir = Path(app.config["DATA_DIR"])
+    base = Path(app.instance_path)
+
+    paths = {
+        base,
+        base / ".tmp",
+        base / "uploads",
+        base / "exports",
+        base / "logs",
+        data_dir,
+        data_dir / "uploads",
+        data_dir / "logs",
+    }
+
+    for path in paths:
+        path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- update the testing configuration to rely on an in-memory SQLite database with thread-safe engine options
- ensure required instance and data directories exist before database initialization
- expand directory creation helper to build all runtime folders for instance and DATA_DIR

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d94c85dc8326a043e6da87e3b5ed