### PR TITLE
Add user registration flow with validations and tests

### DIFF
--- a/app/blueprints/auth/templates/auth/register.html
+++ b/app/blueprints/auth/templates/auth/register.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Registro{% endblock %}
+
+{% block content %}
+<h2>Crear cuenta</h2>
+<form method="post" action="{{ url_for('auth.register_post') }}" class="form" style="max-width:420px">
+  <div style="margin:.5rem 0">
+    <label>Email</label><br>
+    <input type="email" name="email" required autofocus style="width:100%">
+  </div>
+  <div style="margin:.5rem 0">
+    <label>Contraseña</label><br>
+    <input type="password" name="password" minlength="8" required style="width:100%">
+    <small>Al menos 8 caracteres</small>
+  </div>
+  <div style="margin:.5rem 0">
+    <label>Confirmar contraseña</label><br>
+    <input type="password" name="confirm" minlength="8" required style="width:100%">
+  </div>
+  <button type="submit">Crear cuenta</button>
+  <p style="margin-top:.5rem">¿Ya tienes cuenta? <a href="{{ url_for('auth.login') }}">Inicia sesión</a></p>
+</form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,6 +18,7 @@
   <a href="/admin/">Admin</a>
   <a href="/admin/files">Archivos</a>
   <a href="/auth/login">Login</a>
+  <a href="/auth/register">Registro</a>
   <a href="/auth/logout">Logout</a>
 </nav>
 

--- a/tests/auth/test_register.py
+++ b/tests/auth/test_register.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from app import create_app
+from app.db import db as _db
+from app.models.user import User
+
+
+@pytest.fixture()
+def app():
+    app = create_app("test")
+    with app.app_context():
+        _db.drop_all()
+        _db.create_all()
+        yield app
+        _db.session.remove()
+        _db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_register_success(app, client):
+    r = client.post(
+        "/auth/register",
+        data={
+            "email": "nuevo@codex.local",
+            "password": "secreto123",
+            "confirm": "secreto123",
+        },
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    assert b"Cuenta creada" in r.data
+
+    # Verificamos en DB
+    from app.db import db
+
+    with app.app_context():
+        u = db.session.query(User).filter_by(email="nuevo@codex.local").one_or_none()
+        assert u is not None
+        assert u.check_password("secreto123") is True
+
+
+def test_register_duplicate_email(app, client):
+    from app.db import db
+
+    with app.app_context():
+        u = User(email="dup@codex.local", is_admin=False)
+        u.set_password("cualquiera123")
+        db.session.add(u)
+        db.session.commit()
+
+    r = client.post(
+        "/auth/register",
+        data={
+            "email": "dup@codex.local",
+            "password": "nuevo12345",
+            "confirm": "nuevo12345",
+        },
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    assert b"ya est\xc3\xa1 registrado" in r.data  # "ya está registrado"
+
+
+def test_register_password_mismatch(client):
+    r = client.post(
+        "/auth/register",
+        data={
+            "email": "mismatch@codex.local",
+            "password": "uno12345",
+            "confirm": "dos12345",
+        },
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    assert b"no coinciden" in r.data
+
+
+def test_register_short_password(client):
+    r = client.post(
+        "/auth/register",
+        data={
+            "email": "short@codex.local",
+            "password": "123",
+            "confirm": "123",
+        },
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    assert b"al menos 8" in r.data
+
+
+def test_register_bad_email(client):
+    r = client.post(
+        "/auth/register",
+        data={
+            "email": "sin-arroba",
+            "password": "secreto123",
+            "confirm": "secreto123",
+        },
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    assert b"Email inv\xc3\xa1lido" in r.data  # "Email inválido"


### PR DESCRIPTION
## Summary
- add register form and submission routes with validation feedback
- create registration template and navigation link
- cover registration scenarios with pytest module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca045198cc83268a44ebfff39f1d60