### PR TITLE
feat: reset password without email link flow

### DIFF
--- a/app/blueprints/auth/templates/auth/forgot_password.html
+++ b/app/blueprints/auth/templates/auth/forgot_password.html
@@ -7,6 +7,9 @@
     <label>Email</label><br>
     <input type="email" name="email" required style="width:100%">
   </div>
-  <button type="submit">Enviar enlace</button>
+  <button type="submit">Generar enlace</button>
 </form>
+<p style="margin-top:.5rem; font-size:.9rem; color:#555">
+  No enviamos correos en esta etapa. Si la cuenta existe, verás el enlace en la pantalla siguiente.
+</p>
 {% endblock %}

--- a/app/blueprints/auth/templates/auth/forgot_password_sent.html
+++ b/app/blueprints/auth/templates/auth/forgot_password_sent.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Enlace de restablecimiento{% endblock %}
+{% block content %}
+<h2>Enlace de restablecimiento</h2>
+<p>Si la cuenta existe, se generó un enlace temporal válido por 1 hora.</p>
+
+{% if reset_url %}
+  <p><strong>Enlace:</strong> <a href="{{ reset_url }}" target="_blank">{{ reset_url }}</a></p>
+  <p style="font-size:.9rem;color:#555">
+    Guarda este enlace en un lugar seguro. También fue registrado en logs del servidor.
+  </p>
+{% else %}
+  <p>No se muestra el enlace por seguridad.</p>
+{% endif %}
+
+<p><a href="{{ url_for('auth.login') }}">Volver al login</a></p>
+{% endblock %}

--- a/app/security.py
+++ b/app/security.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from flask import current_app
 
@@ -7,7 +6,7 @@ from flask import current_app
 def _serializer() -> URLSafeTimedSerializer:
     return URLSafeTimedSerializer(
         current_app.config["SECRET_KEY"],
-        salt=current_app.config.get("SECURITY_PASSWORD_SALT", "salt"),
+        salt=current_app.config.get("SECURITY_PASSWORD_SALT", "dev-salt"),
     )
 
 
@@ -17,21 +16,6 @@ def generate_reset_token(email: str) -> str:
 
 def parse_reset_token(token: str, max_age: int = 3600) -> str | None:
     try:
-        email = _serializer().loads(token, max_age=max_age)
-        return email
+        return _serializer().loads(token, max_age=max_age)
     except (BadSignature, SignatureExpired):
         return None
-
-
-def send_reset_link(email: str, url: str) -> None:
-    """
-    Envía el link de reseteo. Si no hay SMTP configurado, lo manda a logs.
-    """
-    app = current_app
-    server = app.config.get("MAIL_SERVER", "")
-    if not server:
-        app.logger.warning("[RESET-PASS] %s -> %s", email, url)
-        return
-
-    # Opcional: si quieres usar Flask-Mail, colócalo aquí; por simplicidad: logs
-    app.logger.info("[RESET-PASS] Email enviado a %s: %s", email, url)

--- a/tests/auth/test_forgot_without_email.py
+++ b/tests/auth/test_forgot_without_email.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from app import create_app
+from app.db import db
+from app.models.user import User
+
+
+def setup_app():
+    app = create_app("test")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    return app
+
+
+def test_forgot_generates_link_when_user_exists():
+    app = setup_app()
+    with app.app_context():
+        u = User(email="demo@codex.local", is_admin=False)
+        u.set_password("demo12345")
+        db.session.add(u)
+        db.session.commit()
+
+    client = app.test_client()
+    r = client.post(
+        "/auth/forgot-password",
+        data={"email": "demo@codex.local"},
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    assert b"/auth/reset-password/" in r.data  # se muestra el link
+
+
+def test_forgot_neutral_when_user_not_exists():
+    app = setup_app()
+    client = app.test_client()
+    r = client.post(
+        "/auth/forgot-password",
+        data={"email": "noexiste@codex.local"},
+        follow_redirects=True,
+    )
+    assert r.status_code == 200
+    # no debe exponer datos, pero muestra pantalla de enviado
+    assert b"Enlace de restablecimiento" in r.data


### PR DESCRIPTION
## Summary
- generate and validate password reset tokens locally without sending emails
- expose the reset link in the forgot password confirmation UI and log the URL
- cover the no-email reset flow with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca327b65ac83269903b58f79119fae