### PR TITLE
feat(admin): listado de usuarios y generación de enlace de reset por admin

### DIFF
--- a/app/blueprints/admin/templates/admin/reset_link.html
+++ b/app/blueprints/admin/templates/admin/reset_link.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Enlace de reset{% endblock %}
+{% block content %}
+<h2>Enlace de restablecimiento</h2>
+<p>Usuario: <strong>{{ user.email }}</strong></p>
+
+{% if reset_url %}
+  <p><strong>Link:</strong> <a href="{{ reset_url }}" target="_blank">{{ reset_url }}</a></p>
+  <p style="font-size:.9rem;color:#555">
+    Copia este enlace y compártelo al usuario por un canal seguro.
+    Es válido por 1 hora y también quedó registrado en los logs del servidor.
+  </p>
+{% else %}
+  <p>No se pudo generar el enlace.</p>
+{% endif %}
+
+<p><a href="{{ url_for('admin.admin_users') }}">Volver a usuarios</a></p>
+{% endblock %}

--- a/app/blueprints/admin/templates/admin/users.html
+++ b/app/blueprints/admin/templates/admin/users.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Usuarios{% endblock %}
+{% block content %}
+<h2>Usuarios</h2>
+<p><a href="{{ url_for('admin.admin_new_user') }}">➕ Crear usuario</a></p>
+<table border="1" cellspacing="0" cellpadding="6">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Email</th>
+      <th>Admin</th>
+      <th>Creado</th>
+      <th>Acciones</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for u in users %}
+    <tr>
+      <td>{{ u.id }}</td>
+      <td>{{ u.email }}</td>
+      <td>{{ 'Sí' if u.is_admin else 'No' }}</td>
+      <td>{{ u.created_at }}</td>
+      <td>
+        <form method="post" action="{{ url_for('admin.admin_user_reset_link', user_id=u.id) }}" style="display:inline">
+          <button type="submit">🔗 Generar enlace de reset</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,6 +25,7 @@
     <a href="{{ url_for('auth.forgot_password') }}">¿Olvidaste tu contraseña?</a>
   {% endif %}
   {% if current_user.is_authenticated and current_user.is_admin %}
+    <a href="{{ url_for('admin.admin_users') }}">Usuarios</a>
     <a href="{{ url_for('admin.admin_new_user') }}">Crear usuario</a>
   {% endif %}
 </nav>

--- a/tests/admin/test_admin_reset_link.py
+++ b/tests/admin/test_admin_reset_link.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from app import create_app
+from app.db import db
+from app.models.user import User
+
+
+def setup_app():
+    app = create_app("test")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(email="admin@codex.local", is_admin=True)
+        admin.set_password("admin12345")
+        u = User(email="user@codex.local", is_admin=False)
+        u.set_password("user12345")
+        db.session.add_all([admin, u])
+        db.session.commit()
+    return app
+
+
+def login(client, email, password):
+    return client.post(
+        "/auth/login",
+        data={"email": email, "password": password},
+        follow_redirects=True,
+    )
+
+
+def test_admin_generates_reset_link():
+    app = setup_app()
+    client = app.test_client()
+    login(client, "admin@codex.local", "admin12345")
+
+    r = client.get("/admin/users")
+    assert r.status_code == 200
+    assert b"user@codex.local" in r.data
+
+    with app.app_context():
+        user = db.session.query(User).filter_by(email="user@codex.local").one()
+    r2 = client.post(f"/admin/users/{user.id}/reset-link", follow_redirects=True)
+    assert r2.status_code == 200
+    assert b"/auth/reset-password/" in r2.data


### PR DESCRIPTION
## Summary
- add admin user listing route with reset-link generation flow
- create admin templates for listing users and displaying generated reset links
- expose admin user listing in navigation and cover the flow with tests

## Testing
- pytest tests/admin/test_admin_reset_link.py

------
https://chatgpt.com/codex/tasks/task_e_68ca4079ad70832694d2ea89b7b8c4b9