### PR TITLE
feat: enforce password change when flagged users log in

### DIFF
--- a/app/blueprints/admin/templates/admin/new_user.html
+++ b/app/blueprints/admin/templates/admin/new_user.html
@@ -14,6 +14,9 @@
   <div style="margin:.5rem 0">
     <label><input type="checkbox" name="is_admin"> ¿Administrador?</label>
   </div>
+  <div style="margin:.5rem 0">
+    <label><input type="checkbox" name="force_change"> ¿Requerir cambio de contraseña al primer login?</label>
+  </div>
   <button type="submit">Crear</button>
   <p style="margin-top:.5rem"><a href="{{ url_for('admin.index') }}">Volver</a></p>
 </form>

--- a/app/blueprints/admin/templates/admin/users.html
+++ b/app/blueprints/admin/templates/admin/users.html
@@ -10,6 +10,7 @@
       <th>Email</th>
       <th>Admin</th>
       <th>Creado</th>
+      <th>Forzar cambio</th>
       <th>Acciones</th>
     </tr>
   </thead>
@@ -20,9 +21,17 @@
       <td>{{ u.email }}</td>
       <td>{{ 'Sí' if u.is_admin else 'No' }}</td>
       <td>{{ u.created_at }}</td>
+      <td>{{ 'Sí' if u.force_change_password else 'No' }}</td>
       <td>
         <form method="post" action="{{ url_for('admin.admin_user_reset_link', user_id=u.id) }}" style="display:inline">
-          <button type="submit">🔗 Generar enlace de reset</button>
+          <button type="submit">🔗 Enlace de reset</button>
+        </form>
+        <form method="post" action="{{ url_for('admin.admin_user_toggle_force', user_id=u.id) }}" style="display:inline;margin-left:.5rem">
+          {% if u.force_change_password %}
+            <button type="submit">❎ Quitar forzado</button>
+          {% else %}
+            <button type="submit">✅ Forzar cambio</button>
+          {% endif %}
         </form>
       </td>
     </tr>

--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -33,6 +33,9 @@ def login_post():
         return redirect(url_for("auth.login"))
 
     login_user(user)
+    if getattr(user, "force_change_password", False):
+        flash("Debes actualizar tu contraseña antes de continuar.", "info")
+        return redirect(url_for("auth.change_password"))
     flash("Bienvenido 👋", "success")
     return redirect(url_for("admin.index"))
 
@@ -71,6 +74,7 @@ def change_password_post():
         return redirect(url_for("auth.change_password"))
 
     current_user.set_password(new)
+    current_user.force_change_password = False
     db.session.commit()
     flash("Contraseña actualizada.", "success")
     return redirect(url_for("admin.index"))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -18,6 +18,7 @@ class User(db.Model, UserMixin):
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    force_change_password: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
@@ -32,6 +33,7 @@ class User(db.Model, UserMixin):
             "id": self.id,
             "email": self.email,
             "is_admin": self.is_admin,
+            "force_change_password": self.force_change_password,
             "is_active": self.is_active,
             "created_at": self.created_at.isoformat() + "Z",
         }

--- a/migrations/versions/20250916_add_force_change_password.py
+++ b/migrations/versions/20250916_add_force_change_password.py
@@ -1,0 +1,21 @@
+"""add force_change_password to users"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20250916_add_force_change_password"
+down_revision = "20240201_create_users"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users",
+        sa.Column("force_change_password", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.alter_column("users", "force_change_password", server_default=None)
+
+
+def downgrade():
+    op.drop_column("users", "force_change_password")

--- a/tests/auth/test_force_change_password.py
+++ b/tests/auth/test_force_change_password.py
@@ -1,0 +1,54 @@
+from app import create_app
+from app.db import db
+from app.models.user import User
+
+
+def setup_app():
+    app = create_app("test")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        u = User(email="force@codex.local", is_admin=False, force_change_password=True)
+        u.set_password("secreto123")
+        db.session.add(u)
+        db.session.commit()
+    return app
+
+
+def test_force_change_redirects_to_change_password():
+    app = setup_app()
+    client = app.test_client()
+    response = client.post(
+        "/auth/login",
+        data={"email": "force@codex.local", "password": "secreto123"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)
+    assert "/auth/change-password" in response.headers.get("Location", "")
+
+
+def test_change_password_clears_flag():
+    app = setup_app()
+    client = app.test_client()
+    client.post(
+        "/auth/login",
+        data={"email": "force@codex.local", "password": "secreto123"},
+        follow_redirects=True,
+    )
+    response = client.post(
+        "/auth/change-password",
+        data={
+            "current": "secreto123",
+            "new": "nuevo12345",
+            "confirm": "nuevo12345",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    client.get("/auth/logout", follow_redirects=True)
+    response_login = client.post(
+        "/auth/login",
+        data={"email": "force@codex.local", "password": "nuevo12345"},
+        follow_redirects=True,
+    )
+    assert response_login.status_code == 200


### PR DESCRIPTION
## Summary
- add a persistent `force_change_password` flag to the `User` model with migration support
- redirect flagged users to the change password screen and reset the flag once they update their credentials
- expose admin controls to set the flag when creating or managing users and cover the flow with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca513aa2008326b342b70d81638982