### PR TITLE
fix: make force_change_password migration sqlite-safe

### DIFF
--- a/migrations/versions/20250916_add_force_change_password.py
+++ b/migrations/versions/20250916_add_force_change_password.py
@@ -1,8 +1,8 @@
-"""add force_change_password to users"""
+"""add force_change_password to users (sqlite-safe)"""
 from alembic import op
 import sqlalchemy as sa
 
-# revision identifiers, used by Alembic.
+# OJO: deja estos IDs como los tienes en tu repo
 revision = "20250916_add_force_change_password"
 down_revision = "20240201_create_users"
 branch_labels = None
@@ -10,11 +10,21 @@ depends_on = None
 
 
 def upgrade():
+    # Añadimos la columna con default False para que SQLite permita NOT NULL
     op.add_column(
         "users",
-        sa.Column("force_change_password", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "force_change_password",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
     )
-    op.alter_column("users", "force_change_password", server_default=None)
+
+    # Si NO es SQLite, puedes quitar el default (opcional)
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        op.alter_column("users", "force_change_password", server_default=None)
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- update the `20250916_add_force_change_password` migration to add the column with a SQLite-safe default and remove it only on non-SQLite engines

## Testing
- not run (migration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca55c818848326bef6f9354b01b38b