### PR TITLE
fix(templates): evita uso directo de current_app en base.html y añade context processor seguro

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,6 +35,15 @@ def create_app(config_name: str | None = None) -> Flask:
     init_migrations(app, db)
     init_auth_extensions(app)
 
+    # Variables globales seguras para Jinja (evita usar `current_app` en plantillas)
+    @app.context_processor
+    def inject_nav_targets():
+        try:
+            has_web_index = "web.index" in app.view_functions
+        except Exception:
+            has_web_index = False
+        return {"has_web_index": has_web_index}
+
     # Blueprints
     from . import models  # noqa: F401
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -22,7 +22,12 @@
 <body>
   <nav class="container">
     <ul>
-      <li><strong>SGC</strong></li>
+      <li>
+        <a class="brand"
+           href="{{ url_for('web.index') if has_web_index else url_for('auth.login') }}">
+          SGC
+        </a>
+      </li>
     </ul>
     <ul>
       <li><a href="/">Inicio</a></li>


### PR DESCRIPTION
## Summary
- add a global context processor that exposes the `has_web_index` flag safely to templates
- update the base template brand link to rely on the injected flag instead of `current_app`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca7b0a7a008326a33141ee85a3ec39