### PR TITLE
Update navbar CTA to external company site

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,6 +46,11 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('auth.login') }}">Entrar</a>
             </li>
+            <li class="nav-item ms-lg-3">
+              <a class="btn btn-primary" href="https://www.dusiglo21.com" target="_blank">
+                Acerca de nosotros
+              </a>
+            </li>
             <li class="nav-item">
               <a class="btn btn-outline-primary ms-lg-3" href="{{ url_for('admin.index') }}">Panel Admin</a>
             </li>

--- a/tests/web/test_home.py
+++ b/tests/web/test_home.py
@@ -14,8 +14,11 @@ def test_home_renders_homepage(client) -> None:
 
     html = res.get_data(as_text=True)
 
-    assert "Sistema de Gestión de Calidad" in html
+    assert "SGC · Sistema de Gestión de Calidad" in html
     assert "Huasteca Fuel Terminal" in html
+
+    assert "https://www.dusiglo21.com" in html
+    assert "Acerca de nosotros" in html
 
 
 def test_health_returns_ok() -> None:


### PR DESCRIPTION
## Summary
- replace the navbar call-to-action with a button linking to the company website
- extend the homepage test assertions to cover the new CTA

## Testing
- pytest tests/web/test_home.py

------
https://chatgpt.com/codex/tasks/task_e_68ca8d0c74608326ac54a472a8c6f8c8