### PR TITLE
feat: login por username y ajustes de usuarios

### DIFF
--- a/app/blueprints/admin/templates/admin/new_user.html
+++ b/app/blueprints/admin/templates/admin/new_user.html
@@ -4,8 +4,12 @@
 <h2>Crear usuario</h2>
 <form method="post" action="{{ url_for('admin.admin_create_user') }}" class="form" style="max-width:460px">
   <div style="margin:.5rem 0">
-    <label>Email</label><br>
-    <input type="email" name="email" required autofocus style="width:100%">
+    <label>Usuario</label><br>
+    <input type="text" name="username" required autofocus style="width:100%">
+  </div>
+  <div style="margin:.5rem 0">
+    <label>Email (opcional)</label><br>
+    <input type="email" name="email" style="width:100%">
   </div>
   <div style="margin:.5rem 0">
     <label>Contraseña</label><br>

--- a/app/blueprints/admin/templates/admin/reset_link.html
+++ b/app/blueprints/admin/templates/admin/reset_link.html
@@ -2,7 +2,8 @@
 {% block title %}Enlace de reset{% endblock %}
 {% block content %}
 <h2>Enlace de restablecimiento</h2>
-<p>Usuario: <strong>{{ user.email }}</strong></p>
+<p>Usuario: <strong>{{ user.username }}</strong></p>
+<p>Email: <strong>{{ user.email or '—' }}</strong></p>
 
 {% if reset_url %}
   <p><strong>Link:</strong> <a href="{{ reset_url }}" target="_blank">{{ reset_url }}</a></p>

--- a/app/blueprints/admin/templates/admin/users.html
+++ b/app/blueprints/admin/templates/admin/users.html
@@ -8,6 +8,7 @@
     <thead>
       <tr>
         <th>ID</th>
+        <th>Usuario</th>
         <th>Email</th>
         <th>Admin</th>
         <th>Forzar cambio</th>
@@ -18,7 +19,8 @@
       {% for u in users %}
       <tr>
         <td>{{ u.id }}</td>
-        <td>{{ u.email }}</td>
+        <td>{{ u.username }}</td>
+        <td>{{ u.email or '—' }}</td>
         <td>{{ 'Sí' if u.is_admin else 'No' }}</td>
         <td>{{ 'Sí' if u.force_change_password else 'No' }}</td>
         <td>

--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -24,12 +24,12 @@ def login():
 
 @bp_auth.post("/login")
 def login_post():
-    email = request.form.get("email", "").strip().lower()
-    password = request.form.get("password", "")
+    username = (request.form.get("username") or "").strip()
+    password = request.form.get("password") or ""
 
-    user = db.session.query(User).filter_by(email=email).one_or_none()
-    if not user or not user.check_password(password):
-        flash("Credenciales inválidas", "danger")
+    user = User.query.filter_by(username=username).first()
+    if not user or not user.check_password(password) or not user.is_active:
+        flash("Credenciales inválidas o usuario inactivo.", "danger")
         return redirect(url_for("auth.login"))
 
     login_user(user)

--- a/app/blueprints/auth/templates/auth/login.html
+++ b/app/blueprints/auth/templates/auth/login.html
@@ -4,13 +4,13 @@
 <article>
   <h2>Iniciar sesión</h2>
   <form method="post" action="{{ url_for('auth.login_post') }}">
-    <label>
-      Email
-      <input type="email" name="email" required>
+    <label class="form-label">
+      Usuario
+      <input class="form-control" type="text" name="username" required autofocus>
     </label>
-    <label>
+    <label class="form-label">
       Contraseña
-      <input type="password" name="password" required>
+      <input class="form-control" type="password" name="password" required>
     </label>
     <button type="submit">Entrar</button>
   </form>

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -4,8 +4,9 @@ from datetime import datetime
 from typing import Any
 
 from flask_login import UserMixin
-from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy import Boolean, DateTime, Index, String
 from sqlalchemy.orm import Mapped, mapped_column
+from werkzeug.security import check_password_hash, generate_password_hash
 
 from app.db import db
 from app.extensions import bcrypt, login_manager
@@ -15,22 +16,32 @@ class User(db.Model, UserMixin):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    email: Mapped[str | None] = mapped_column(String(254), unique=False, nullable=True, index=True)
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     force_change_password: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
+    __table_args__ = (Index("ix_users_username", "username"),)
+
     def set_password(self, password: str) -> None:
-        self.password_hash = bcrypt.generate_password_hash(password or "").decode("utf-8")
+        self.password_hash = generate_password_hash(password or "")
 
     def check_password(self, password: str) -> bool:
-        return bcrypt.check_password_hash(self.password_hash, password)
+        stored = self.password_hash or ""
+        if stored.startswith("$2"):
+            try:
+                return bcrypt.check_password_hash(stored, password)
+            except Exception:
+                pass
+        return check_password_hash(stored, password)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
+            "username": self.username,
             "email": self.email,
             "is_admin": self.is_admin,
             "force_change_password": self.force_change_password,
@@ -39,7 +50,7 @@ class User(db.Model, UserMixin):
         }
 
     def __repr__(self) -> str:
-        return f"<User {self.email}>"
+        return f"<User {self.username}>"
 
 
 @login_manager.user_loader

--- a/app/scripts/ensure_admin.py
+++ b/app/scripts/ensure_admin.py
@@ -11,20 +11,30 @@ from app.models.user import User
 
 def main() -> None:
     app: Flask = create_app()
-    admin_email = os.environ.get("ADMIN_EMAIL", "admin@codex.local").strip().lower()
-    admin_password = os.environ.get("ADMIN_PASSWORD", "admin12345")
+    username = os.environ.get("ADMIN_USERNAME", "admin")
+    password = os.environ.get("ADMIN_PASSWORD", "admin")
 
     with app.app_context():
-        u = db.session.query(User).filter_by(email=admin_email).one_or_none()
+        u = User.query.filter_by(username=username).first()
         if u:
-            app.logger.info("[ensure_admin] Admin ya existe: %s", admin_email)
+            app.logger.info("[ensure_admin] ya existe '%s'", username)
             return
 
-        u = User(email=admin_email, is_admin=True, force_change_password=False)
-        u.set_password(admin_password)
+        u = User(
+            username=username,
+            email=None,
+            is_admin=True,
+            is_active=True,
+            force_change_password=False,
+        )
+        u.set_password(password)
         db.session.add(u)
         db.session.commit()
-        app.logger.warning("[ensure_admin] Admin creado: %s", admin_email)
+        app.logger.warning(
+            "[ensure_admin] creado admin '%s' con password '%s'",
+            username,
+            password,
+        )
 
 
 if __name__ == "__main__":

--- a/migrations/versions/20250917_usernames.py
+++ b/migrations/versions/20250917_usernames.py
@@ -1,0 +1,72 @@
+"""add username (unique, not null) and make email nullable"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20250917_usernames"
+down_revision = "20250916_add_force_change_password"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("username", sa.String(length=64), nullable=True))
+    op.create_index("ix_users_username", "users", ["username"], unique=False)
+
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id, email FROM users ORDER BY id")).fetchall()
+    taken: set[str] = set()
+    for rid, email in rows:
+        base = None
+        if email:
+            base = email.split("@", 1)[0].strip() or None
+        if not base:
+            base = f"user{rid}"
+        candidate = base[:64]
+        original = candidate or f"user{rid}"
+        candidate = original
+        counter = 1
+        while not candidate or candidate in taken:
+            suffix = str(counter)
+            trimmed = original[: max(1, 64 - len(suffix))]
+            candidate = f"{trimmed}{suffix}"
+            counter += 1
+        taken.add(candidate)
+        conn.execute(
+            sa.text("UPDATE users SET username=:u WHERE id=:id"),
+            {"u": candidate, "id": rid},
+        )
+
+    op.alter_column(
+        "users",
+        "username",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )
+    op.create_unique_constraint("uq_users_username", "users", ["username"])
+
+    op.drop_index("ix_users_email", table_name="users")
+    with op.batch_alter_table("users") as batch:
+        batch.alter_column(
+            "email",
+            existing_type=sa.String(length=254),
+            nullable=True,
+        )
+    op.create_index("ix_users_email", "users", ["email"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_email", table_name="users")
+    with op.batch_alter_table("users") as batch:
+        batch.alter_column(
+            "email",
+            existing_type=sa.String(length=254),
+            nullable=False,
+        )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.drop_constraint("uq_users_username", "users", type_="unique")
+    op.drop_index("ix_users_username", table_name="users")
+    op.drop_column("users", "username")

--- a/tests/admin/test_admin_auth.py
+++ b/tests/admin/test_admin_auth.py
@@ -15,7 +15,7 @@ def app_with_admin(tmp_path, monkeypatch):
     app = create_app("test")
     with app.app_context():
         db.create_all()
-        admin = User(email="admin@codex.local", is_admin=True)
+        admin = User(username="admin", email="admin@codex.local", is_admin=True)
         admin.set_password("admin123")
         db.session.add(admin)
         db.session.commit()
@@ -39,7 +39,7 @@ def test_admin_login_ok_and_access(app_with_admin):
 
     response = client.post(
         "/auth/login",
-        data={"email": "admin@codex.local", "password": "admin123"},
+        data={"username": "admin", "password": "admin123"},
         follow_redirects=True,
     )
 
@@ -64,7 +64,7 @@ def test_admin_login_wrong_password(app_with_admin):
 
     response = client.post(
         "/auth/login",
-        data={"email": "admin@codex.local", "password": "wrong"},
+        data={"username": "admin", "password": "wrong"},
         follow_redirects=False,
     )
 

--- a/tests/admin/test_admin_reset_link.py
+++ b/tests/admin/test_admin_reset_link.py
@@ -10,19 +10,19 @@ def setup_app():
     with app.app_context():
         db.drop_all()
         db.create_all()
-        admin = User(email="admin@codex.local", is_admin=True)
+        admin = User(username="admin", email="admin@codex.local", is_admin=True)
         admin.set_password("admin12345")
-        u = User(email="user@codex.local", is_admin=False)
+        u = User(username="user", email="user@codex.local", is_admin=False)
         u.set_password("user12345")
         db.session.add_all([admin, u])
         db.session.commit()
     return app
 
 
-def login(client, email, password):
+def login(client, username, password):
     return client.post(
         "/auth/login",
-        data={"email": email, "password": password},
+        data={"username": username, "password": password},
         follow_redirects=True,
     )
 
@@ -30,7 +30,7 @@ def login(client, email, password):
 def test_admin_generates_reset_link():
     app = setup_app()
     client = app.test_client()
-    login(client, "admin@codex.local", "admin12345")
+    login(client, "admin", "admin12345")
 
     r = client.get("/admin/users")
     assert r.status_code == 200

--- a/tests/auth/test_force_change_password.py
+++ b/tests/auth/test_force_change_password.py
@@ -8,7 +8,12 @@ def setup_app():
     with app.app_context():
         db.drop_all()
         db.create_all()
-        u = User(email="force@codex.local", is_admin=False, force_change_password=True)
+        u = User(
+            username="force",
+            email="force@codex.local",
+            is_admin=False,
+            force_change_password=True,
+        )
         u.set_password("secreto123")
         db.session.add(u)
         db.session.commit()
@@ -20,7 +25,7 @@ def test_force_change_redirects_to_change_password():
     client = app.test_client()
     response = client.post(
         "/auth/login",
-        data={"email": "force@codex.local", "password": "secreto123"},
+        data={"username": "force", "password": "secreto123"},
         follow_redirects=False,
     )
     assert response.status_code in (302, 303)
@@ -32,7 +37,7 @@ def test_change_password_clears_flag():
     client = app.test_client()
     client.post(
         "/auth/login",
-        data={"email": "force@codex.local", "password": "secreto123"},
+        data={"username": "force", "password": "secreto123"},
         follow_redirects=True,
     )
     response = client.post(
@@ -48,7 +53,7 @@ def test_change_password_clears_flag():
     client.get("/auth/logout", follow_redirects=True)
     response_login = client.post(
         "/auth/login",
-        data={"email": "force@codex.local", "password": "nuevo12345"},
+        data={"username": "force", "password": "nuevo12345"},
         follow_redirects=True,
     )
     assert response_login.status_code == 200

--- a/tests/auth/test_forgot_without_email.py
+++ b/tests/auth/test_forgot_without_email.py
@@ -16,7 +16,7 @@ def setup_app():
 def test_forgot_generates_link_when_user_exists():
     app = setup_app()
     with app.app_context():
-        u = User(email="demo@codex.local", is_admin=False)
+        u = User(username="demo", email="demo@codex.local", is_admin=False)
         u.set_password("demo12345")
         db.session.add(u)
         db.session.commit()

--- a/tests/auth/test_login_username.py
+++ b/tests/auth/test_login_username.py
@@ -1,0 +1,26 @@
+from app import create_app
+from app.db import db
+from app.models.user import User
+
+
+def setup_app():
+    app = create_app("test")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        u = User(username="admin", email=None, is_admin=True, is_active=True)
+        u.set_password("admin")
+        db.session.add(u)
+        db.session.commit()
+    return app
+
+
+def test_login_with_username():
+    app = setup_app()
+    client = app.test_client()
+    r = client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "admin"},
+        follow_redirects=False,
+    )
+    assert r.status_code in (302, 303)

--- a/tests/auth/test_password_flows.py
+++ b/tests/auth/test_password_flows.py
@@ -13,9 +13,9 @@ def app():
         db.drop_all()
         db.create_all()
         # admin + normal
-        admin = User(email="admin@codex.local", is_admin=True)
+        admin = User(username="admin", email="admin@codex.local", is_admin=True)
         admin.set_password("admin1234")
-        user = User(email="user@codex.local", is_admin=False)
+        user = User(username="user", email="user@codex.local", is_admin=False)
         user.set_password("user12345")
         db.session.add_all([admin, user])
         db.session.commit()
@@ -29,16 +29,16 @@ def client(app):
     return app.test_client()
 
 
-def login(client, email, password):
+def login(client, username, password):
     return client.post(
         "/auth/login",
-        data={"email": email, "password": password},
+        data={"username": username, "password": password},
         follow_redirects=True,
     )
 
 
 def test_change_password_ok(client):
-    login(client, "user@codex.local", "user12345")
+    login(client, "user", "user12345")
     r = client.post(
         "/auth/change-password",
         data={"current": "user12345", "new": "nuevo12345", "confirm": "nuevo12345"},
@@ -47,7 +47,7 @@ def test_change_password_ok(client):
     assert r.status_code == 200
     # re-login con nueva
     client.get("/auth/logout", follow_redirects=True)
-    r2 = login(client, "user@codex.local", "nuevo12345")
+    r2 = login(client, "user", "nuevo12345")
     assert r2.status_code == 200
 
 
@@ -62,5 +62,5 @@ def test_reset_password_ok(client, app):
     )
     assert r.status_code == 200
     # login con nueva
-    r2 = login(client, "user@codex.local", "rest12345")
+    r2 = login(client, "user", "rest12345")
     assert r2.status_code == 200

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -12,7 +12,7 @@ def _create_app_with_admin(tmp_path, monkeypatch):
     app = create_app("test")
     with app.app_context():
         db.create_all()
-        admin = User(email="admin@example.com", is_admin=True)
+        admin = User(username="admin", email="admin@example.com", is_admin=True)
         admin.set_password("pass123")
         db.session.add(admin)
         db.session.commit()
@@ -31,7 +31,7 @@ def test_admin_files_listing(tmp_path, monkeypatch):
     try:
         client.post(
             "/auth/login",
-            data={"email": "admin@example.com", "password": "pass123"},
+            data={"username": "admin", "password": "pass123"},
             follow_redirects=True,
         )
 


### PR DESCRIPTION
## Summary
- agregar columna `username` al modelo `User`, hacer el email opcional y migrar datos existentes
- actualizar el login y las vistas/admin scripts para autenticación por nombre de usuario
- ajustar el API de usuarios y pruebas para manejar usernames y crear admin inicial por script

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca94525f4083269bbf21825779c627