### PR TITLE
feat: add hierarchical folders management

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from flask import Flask
 from .api.v1 import bp as bp_api_v1
 from .blueprints.admin import bp_admin
 from .blueprints.auth import bp_auth
+from .blueprints.folders import bp_folders
 from .config import get_config
 from .db import db
 from .extensions import init_auth_extensions
@@ -50,6 +51,7 @@ def create_app(config_name: str | None = None) -> Flask:
     app.register_blueprint(bp_auth, url_prefix="/auth")
     app.register_blueprint(bp_web)
     app.register_blueprint(bp_admin, url_prefix="/admin")
+    app.register_blueprint(bp_folders, url_prefix="/folders")
     app.register_blueprint(bp_api_v1, url_prefix="/api/v1")
 
     return app

--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "web",
     "auth",
     "admin",
+    "folders",
 ]

--- a/app/blueprints/folders/__init__.py
+++ b/app/blueprints/folders/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp_folders = Blueprint("folders", __name__, template_folder="templates")
+
+from . import routes  # noqa: E402,F401

--- a/app/blueprints/folders/routes.py
+++ b/app/blueprints/folders/routes.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from flask import flash, redirect, render_template, request, url_for
+from flask_login import login_required
+
+from app.db import db
+from app.models.folder import Folder
+from app.storage import ensure_folder_dir, remove_folder_dir_if_empty
+from app.utils.slugify import slugify
+
+from . import bp_folders
+
+
+def _get_root() -> Folder:
+    root = Folder.query.filter_by(is_root=True).first()
+    if not root:
+        root = Folder(name="Raíz", slug="raiz", is_root=True, parent_id=None)
+        db.session.add(root)
+        db.session.commit()
+        ensure_folder_dir(root.id)
+    return root
+
+
+@bp_folders.get("/")
+@login_required
+def index():
+    root = _get_root()
+    top = Folder.query.filter_by(parent_id=root.id).order_by(Folder.name.asc()).all()
+    return render_template("folders/index.html", root=root, top=top)
+
+
+@bp_folders.get("/<int:folder_id>")
+@login_required
+def show(folder_id: int):
+    folder = db.session.get(Folder, folder_id) or _get_root()
+    children = Folder.query.filter_by(parent_id=folder.id).order_by(Folder.name.asc()).all()
+    parent = db.session.get(Folder, folder.parent_id) if folder.parent_id else None
+    trail: list[Folder] = []
+    current = folder
+    while current:
+        trail.append(current)
+        current = current.parent if current.parent_id else None
+    trail.reverse()
+    return render_template(
+        "folders/show.html",
+        folder=folder,
+        parent=parent,
+        children=children,
+        trail=trail,
+    )
+
+
+@bp_folders.post("/create")
+@login_required
+def create():
+    parent_id = request.form.get("parent_id", type=int)
+    name = (request.form.get("name") or "").strip()
+    if not name:
+        flash("Nombre requerido.", "warning")
+        return redirect(request.referrer or url_for("folders.index"))
+
+    parent = db.session.get(Folder, parent_id) if parent_id else _get_root()
+    slug = slugify(name)
+    exists = Folder.query.filter_by(parent_id=parent.id, slug=slug).first()
+    if exists:
+        flash("Ya existe una carpeta con ese nombre en el mismo nivel.", "danger")
+        return redirect(url_for("folders.show", folder_id=parent.id))
+
+    folder = Folder(name=name, slug=slug, parent_id=parent.id)
+    db.session.add(folder)
+    db.session.commit()
+    ensure_folder_dir(folder.id)
+    flash("Carpeta creada.", "success")
+    return redirect(url_for("folders.show", folder_id=parent.id))
+
+
+@bp_folders.post("/rename/<int:folder_id>")
+@login_required
+def rename(folder_id: int):
+    folder = db.session.get(Folder, folder_id)
+    if not folder or folder.is_root:
+        flash("No se puede renombrar la raíz o carpeta inexistente.", "warning")
+        return redirect(request.referrer or url_for("folders.index"))
+
+    new_name = (request.form.get("name") or "").strip()
+    if not new_name:
+        flash("Nombre requerido.", "warning")
+        return redirect(url_for("folders.show", folder_id=folder.parent_id or folder.id))
+
+    new_slug = slugify(new_name)
+    duplicate = (
+        Folder.query.filter(
+            Folder.parent_id == folder.parent_id,
+            Folder.slug == new_slug,
+            Folder.id != folder.id,
+        )
+        .first()
+    )
+    if duplicate:
+        flash("Ya existe una carpeta con ese nombre en ese nivel.", "danger")
+        return redirect(url_for("folders.show", folder_id=folder.parent_id or folder.id))
+
+    folder.name = new_name
+    folder.slug = new_slug
+    db.session.commit()
+    flash("Carpeta renombrada.", "success")
+    return redirect(url_for("folders.show", folder_id=folder.parent_id or folder.id))
+
+
+@bp_folders.post("/move/<int:folder_id>")
+@login_required
+def move(folder_id: int):
+    folder = db.session.get(Folder, folder_id)
+    if not folder or folder.is_root:
+        flash("No se puede mover la raíz o carpeta inexistente.", "warning")
+        return redirect(request.referrer or url_for("folders.index"))
+
+    new_parent_id = request.form.get("parent_id", type=int)
+    new_parent = db.session.get(Folder, new_parent_id) if new_parent_id else _get_root()
+    if new_parent.id == folder.id:
+        flash("No puedes mover una carpeta dentro de sí misma.", "danger")
+        return redirect(url_for("folders.show", folder_id=folder.parent_id or folder.id))
+
+    current = new_parent
+    while current:
+        if current.id == folder.id:
+            flash("Movimiento inválido (crearía un ciclo).", "danger")
+            return redirect(url_for("folders.show", folder_id=folder.parent_id or folder.id))
+        current = db.session.get(Folder, current.parent_id) if current.parent_id else None
+
+    duplicate = (
+        Folder.query.filter(
+            Folder.parent_id == new_parent.id,
+            Folder.slug == folder.slug,
+            Folder.id != folder.id,
+        )
+        .first()
+    )
+    if duplicate:
+        flash("Ya existe una carpeta con ese nombre en el destino.", "danger")
+        return redirect(url_for("folders.show", folder_id=folder.parent_id or folder.id))
+
+    folder.parent_id = new_parent.id
+    db.session.commit()
+    flash("Carpeta movida.", "success")
+    return redirect(url_for("folders.show", folder_id=new_parent.id))
+
+
+@bp_folders.post("/delete/<int:folder_id>")
+@login_required
+def delete(folder_id: int):
+    folder = db.session.get(Folder, folder_id)
+    if not folder or folder.is_root:
+        flash("No se puede eliminar la raíz o carpeta inexistente.", "warning")
+        return redirect(request.referrer or url_for("folders.index"))
+
+    if folder.children:
+        flash("La carpeta tiene subcarpetas. Elimina o mueve primero su contenido.", "warning")
+        return redirect(url_for("folders.show", folder_id=folder.id))
+
+    parent_id = folder.parent_id
+    db.session.delete(folder)
+    db.session.commit()
+
+    remove_folder_dir_if_empty(folder_id)
+
+    flash("Carpeta eliminada.", "success")
+    return redirect(url_for("folders.show", folder_id=parent_id or _get_root().id))

--- a/app/blueprints/folders/templates/folders/index.html
+++ b/app/blueprints/folders/templates/folders/index.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}SGC · Carpetas{% endblock %}
+{% block content %}
+<section class="py-4">
+  <div class="container">
+    <h3 class="mb-3">Carpetas</h3>
+    <div class="card border-0 shadow-sm">
+      <div class="card-body">
+        <form class="row g-2" method="post" action="{{ url_for('folders.create') }}">
+          <input type="hidden" name="parent_id" value="{{ root.id }}">
+          <div class="col-md-6">
+            <input class="form-control" name="name" placeholder="Nueva carpeta en raíz" required>
+          </div>
+          <div class="col-md-3">
+            <button class="btn btn-primary w-100" type="submit">Crear en raíz</button>
+          </div>
+          <div class="col-md-3 text-end">
+            <a href="{{ url_for('folders.show', folder_id=root.id) }}" class="btn btn-outline-secondary w-100">Ver raíz</a>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div class="mt-4">
+      <h6>Carpetas de primer nivel</h6>
+      <ul class="list-group">
+        {% for f in top %}
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <a href="{{ url_for('folders.show', folder_id=f.id) }}">📂 {{ f.name }}</a>
+          <small class="text-muted">#{{ f.id }}</small>
+        </li>
+        {% else %}
+        <li class="list-group-item text-muted">No hay carpetas aún.</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/app/blueprints/folders/templates/folders/show.html
+++ b/app/blueprints/folders/templates/folders/show.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block title %}SGC · {{ folder.name }}{% endblock %}
+{% block content %}
+<section class="py-4">
+  <div class="container">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        {% for node in trail %}
+          {% if not loop.last %}
+            <li class="breadcrumb-item">
+              <a href="{{ url_for('folders.show', folder_id=node.id) }}">{{ node.name }}</a>
+            </li>
+          {% else %}
+            <li class="breadcrumb-item active" aria-current="page">{{ node.name }}</li>
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </nav>
+
+    <div class="d-flex gap-2 mb-3">
+      {% if parent %}
+        <a class="btn btn-outline-secondary" href="{{ url_for('folders.show', folder_id=parent.id) }}">⬅ Volver</a>
+      {% else %}
+        <a class="btn btn-outline-secondary" href="{{ url_for('folders.index') }}">Inicio carpetas</a>
+      {% endif %}
+    </div>
+
+    <div class="card border-0 shadow-sm">
+      <div class="card-body">
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+          <h4 class="m-0">📂 {{ folder.name }}</h4>
+          {% if not folder.is_root %}
+          <form class="d-flex gap-2" method="post" action="{{ url_for('folders.rename', folder_id=folder.id) }}">
+            <input class="form-control form-control-sm" name="name" placeholder="Renombrar a…" required>
+            <button class="btn btn-sm btn-outline-primary" type="submit">Renombrar</button>
+          </form>
+          <form class="d-flex gap-2" method="post" action="{{ url_for('folders.delete', folder_id=folder.id) }}"
+                onsubmit="return confirm('¿Eliminar carpeta? (Debe estar vacía de subcarpetas)')">
+            <button class="btn btn-sm btn-outline-danger" type="submit">Eliminar</button>
+          </form>
+          {% endif %}
+        </div>
+
+        <hr>
+
+        <form class="row g-2" method="post" action="{{ url_for('folders.create') }}">
+          <input type="hidden" name="parent_id" value="{{ folder.id }}">
+          <div class="col-md-6">
+            <input class="form-control" name="name" placeholder="Nueva subcarpeta" required>
+          </div>
+          <div class="col-md-3">
+            <button class="btn btn-primary w-100" type="submit">Crear</button>
+          </div>
+        </form>
+
+        <div class="mt-4">
+          <h6>Subcarpetas</h6>
+          <ul class="list-group">
+            {% for c in children %}
+            <li class="list-group-item d-flex justify-content-between align-items-center flex-wrap gap-2">
+              <div>
+                <a href="{{ url_for('folders.show', folder_id=c.id) }}">📂 {{ c.name }}</a>
+              </div>
+              <form class="d-flex gap-2 align-items-center" method="post" action="{{ url_for('folders.move', folder_id=c.id) }}">
+                <select class="form-select form-select-sm" name="parent_id">
+                  <option value="{{ folder.id }}">Mantener en {{ folder.name }}</option>
+                  {% if parent %}
+                  <option value="{{ parent.id }}">Mover a {{ parent.name }}</option>
+                  {% endif %}
+                  <option value="">Mover a raíz</option>
+                </select>
+                <button class="btn btn-sm btn-outline-secondary" type="submit">Mover</button>
+              </form>
+            </li>
+            {% else %}
+            <li class="list-group-item text-muted">No hay subcarpetas.</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+{% endblock %}

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,4 @@
 # Importa aquí tus modelos para que Alembic los detecte
 from .todo import Todo  # noqa: F401
 from .user import User  # noqa: F401
+from .folder import Folder  # noqa: F401

--- a/app/models/folder.py
+++ b/app/models/folder.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import db
+
+
+class Folder(db.Model):
+    __tablename__ = "folders"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    slug: Mapped[str] = mapped_column(String(140), nullable=False)
+    parent_id: Mapped[int | None] = mapped_column(
+        ForeignKey("folders.id", ondelete="CASCADE"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    is_root: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    parent: Mapped["Folder"] = relationship(
+        "Folder", remote_side=[id], backref="children", cascade="all,delete"
+    )
+
+    __table_args__ = (UniqueConstraint("parent_id", "slug", name="uq_folders_parent_slug"),)
+
+    def __repr__(self) -> str:
+        return f"<Folder {self.id}:{self.name} parent={self.parent_id}>"

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from pathlib import Path
-from flask import Flask
+import os
+from flask import Flask, current_app
 
 
 def ensure_dirs(app: Flask) -> None:
@@ -20,3 +21,34 @@ def ensure_dirs(app: Flask) -> None:
 
     for path in paths:
         path.mkdir(parents=True, exist_ok=True)
+
+
+def data_dir() -> Path:
+    base = current_app.config.get("DATA_DIR") or os.getenv("DATA_DIR") or "./data"
+    path = Path(base).resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    folders_dir = path / "folders"
+    folders_dir.mkdir(parents=True, exist_ok=True)
+    return folders_dir
+
+
+def folder_path(folder_id: int) -> Path:
+    return data_dir() / str(folder_id)
+
+
+def ensure_folder_dir(folder_id: int) -> Path:
+    folder = folder_path(folder_id)
+    folder.mkdir(parents=True, exist_ok=True)
+    return folder
+
+
+def remove_folder_dir_if_empty(folder_id: int) -> bool:
+    folder = folder_path(folder_id)
+    if not folder.exists():
+        return True
+    try:
+        next(folder.iterdir())
+        return False
+    except StopIteration:
+        folder.rmdir()
+        return True

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utilidades compartidas para la aplicación."""

--- a/app/utils/slugify.py
+++ b/app/utils/slugify.py
@@ -1,0 +1,8 @@
+import re
+from unicodedata import normalize
+
+
+def slugify(text: str) -> str:
+    text = normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    text = re.sub(r"[^a-zA-Z0-9._-]+", "-", text).strip("-").lower()
+    return text or "carpeta"

--- a/migrations/versions/20250917_create_folders.py
+++ b/migrations/versions/20250917_create_folders.py
@@ -1,0 +1,28 @@
+"""create folders table"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20250917_create_folders"
+down_revision = "20250917_usernames"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "folders",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("slug", sa.String(length=140), nullable=False),
+        sa.Column("parent_id", sa.Integer(), sa.ForeignKey("folders.id", ondelete="CASCADE"), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("is_root", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.create_unique_constraint("uq_folders_parent_slug", "folders", ["parent_id", "slug"])
+
+
+def downgrade():
+    op.drop_constraint("uq_folders_parent_slug", "folders", type_="unique")
+    op.drop_table("folders")

--- a/tests/folders/test_folders.py
+++ b/tests/folders/test_folders.py
@@ -1,0 +1,40 @@
+from app import create_app
+from app.db import db
+from app.models.folder import Folder
+from app.models.user import User
+
+
+def setup_app():
+    app = create_app("test")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(username="admin", is_admin=True, is_active=True)
+        user.set_password("admin")
+        db.session.add(user)
+        db.session.commit()
+    return app
+
+
+def login(client):
+    return client.post(
+        "/auth/login", data={"username": "admin", "password": "admin"}, follow_redirects=True
+    )
+
+
+def test_create_folder_happy_path():
+    app = setup_app()
+    client = app.test_client()
+    login(client)
+    client.get("/folders/")
+    with app.app_context():
+        root = Folder.query.filter_by(is_root=True).first()
+        assert root is not None
+        response = client.post(
+            "/folders/create",
+            data={"parent_id": root.id, "name": "Calidad"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        folder = Folder.query.filter_by(parent_id=root.id, slug="calidad").one_or_none()
+        assert folder is not None


### PR DESCRIPTION
## Summary
- add a SQLAlchemy `Folder` model, Alembic migration, and filesystem helpers to manage hierarchical directories
- expose authenticated folder CRUD via a new blueprint with Bootstrap templates and slug handling
- cover folder creation with an integration test and reuse login helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca978b1bd88326a483dfff30e46c34