### PR TITLE
fix: adjust folders migration for SQLite compatibility

### DIFF
--- a/migrations/versions/20250917_create_folders.py
+++ b/migrations/versions/20250917_create_folders.py
@@ -1,28 +1,34 @@
-"""create folders table"""
+"""create folders table (SQLite-safe)"""
 from alembic import op
 import sqlalchemy as sa
 
-
 revision = "20250917_create_folders"
-down_revision = "20250917_usernames"
+down_revision = "20250917_usernames"  # ajusta si tu cadena es distinta
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
+    # Declarar UNIQUE constraint dentro de create_table para evitar ALTER en SQLite.
     op.create_table(
         "folders",
         sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("name", sa.String(length=120), nullable=False),
         sa.Column("slug", sa.String(length=140), nullable=False),
-        sa.Column("parent_id", sa.Integer(), sa.ForeignKey("folders.id", ondelete="CASCADE"), nullable=True),
+        sa.Column("parent_id", sa.Integer(), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),
-        sa.Column("is_root", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        # En SQLite, booleans usan 0/1 como texto; evita 'false' literal
+        sa.Column("is_root", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.ForeignKeyConstraint(["parent_id"], ["folders.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("parent_id", "slug", name="uq_folders_parent_slug"),
     )
-    op.create_unique_constraint("uq_folders_parent_slug", "folders", ["parent_id", "slug"])
+
+    # Índices (sí están soportados en SQLite post-creation)
+    op.create_index("ix_folders_parent_id", "folders", ["parent_id"], unique=False)
+    op.create_index("ix_folders_slug", "folders", ["slug"], unique=False)
 
 
 def downgrade():
-    op.drop_constraint("uq_folders_parent_slug", "folders", type_="unique")
+    # Dropear tabla (borra índices asociados automáticamente en SQLite)
     op.drop_table("folders")


### PR DESCRIPTION
## Summary
- rewrite the folders migration to define the parent/slug unique constraint during table creation
- ensure the is_root default and index creation are compatible with SQLite

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca9e3a0f208326be48db9b83e2be08