### PR TITLE
fix(ui): corrige ruta del logo pequeño (usa static/img/siglo21.png)

### DIFF
--- a/app/blueprints/web/templates/web/index.html
+++ b/app/blueprints/web/templates/web/index.html
@@ -32,7 +32,7 @@
             target="_blank"
           >
             <img
-              src="{{ url_for('static', filename='img/siglo21-logo.png') }}"
+              src="{{ url_for('static', filename='img/siglo21.png') }}"
               alt="Siglo 21"
               style="height: 20px; width: auto;"
             />

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -35,7 +35,7 @@
               style="width: 52px; height: 52px;"
             >
               <img
-                src="{{ url_for('static', filename='img/siglo21-logo.png') }}"
+                src="{{ url_for('static', filename='img/siglo21.png') }}"
                 alt="Siglo 21"
                 style="height: 26px; width: auto;"
               />


### PR DESCRIPTION
## Summary
- actualiza las plantillas públicas para que apunten al recurso `siglo21.png`
- mantiene consistencia visual del logo al eliminar referencias al nombre anterior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb105c99e883268dfb34d3444ba18e