### PR TITLE
Add script to create default admin user

### DIFF
--- a/app/scripts/create_user.py
+++ b/app/scripts/create_user.py
@@ -1,0 +1,26 @@
+from app import create_app
+from app.db import db
+from app.models.user import User
+
+
+def main():
+    app = create_app()
+    with app.app_context():
+        username = "admin"
+        password = "1234"  # cámbialo cuando entres
+        email = None
+
+        existing = User.query.filter_by(username=username).first()
+        if existing:
+            print(f"El usuario '{username}' ya existe")
+            return
+
+        u = User(username=username, email=email, is_admin=True, is_active=True)
+        u.set_password(password)
+        db.session.add(u)
+        db.session.commit()
+        print(f"Usuario '{username}' creado con contraseña '{password}'")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an application script that creates an `admin` user if it does not already exist
- ensure the script sets a default password, marks the user as active and admin, and provides output about the result

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb1ea460a48326807bdd7e52904e16