### PR TITLE
Allow configuring admin user via env vars

### DIFF
--- a/app/scripts/create_user.py
+++ b/app/scripts/create_user.py
@@ -1,3 +1,5 @@
+import os
+
 from app import create_app
 from app.db import db
 from app.models.user import User
@@ -5,21 +7,28 @@ from app.models.user import User
 
 def main():
     app = create_app()
-    with app.app_context():
-        username = "admin"
-        password = "1234"  # cámbialo cuando entres
-        email = None
 
+    username = os.environ.get("ADMIN_USER", "admin")
+    password = os.environ.get("ADMIN_PASS", "1234")
+    email = os.environ.get("ADMIN_EMAIL")  # opcional
+
+    with app.app_context():
         existing = User.query.filter_by(username=username).first()
         if existing:
-            print(f"El usuario '{username}' ya existe")
+            print(f"[INFO] El usuario '{username}' ya existe.")
             return
 
-        u = User(username=username, email=email, is_admin=True, is_active=True)
+        u = User(
+            username=username,
+            email=email,
+            is_admin=True,
+            is_active=True,
+        )
         u.set_password(password)
         db.session.add(u)
         db.session.commit()
-        print(f"Usuario '{username}' creado con contraseña '{password}'")
+
+        print(f"[OK] Usuario '{username}' creado con contraseña '{password}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow overriding default admin username, password, and email via environment variables when running the create_user script
- improve script logging to clarify when the user already exists or is created successfully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb2209a1b483268e0d0da8711f1dec