### PR TITLE
fix(db): unify persistent SQLite config and health check

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
+
 from flask import Flask
 from werkzeug.exceptions import HTTPException
 
@@ -22,6 +24,11 @@ from .storage import ensure_dirs
 def create_app(config_name: str | None = None) -> Flask:
     app = Flask(__name__)
     app.config.from_object(get_config(config_name))
+
+    # Asegura DATA_DIR y muestra la URI (útil en logs de Render)
+    data_dir = Path(app.config.get("DATA_DIR", "./data"))
+    data_dir.mkdir(parents=True, exist_ok=True)
+    app.logger.info("DB URI -> %s", app.config["SQLALCHEMY_DATABASE_URI"])
 
     # Directorios persistentes (DATA_DIR, instance/, etc.)
     ensure_dirs(app)

--- a/app/blueprints/api/v1.py
+++ b/app/blueprints/api/v1.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from flask import Blueprint, Response, jsonify
+from sqlalchemy import text
+
+from app.db import db
 
 bp_api_v1 = Blueprint("api_v1", __name__)
 
@@ -10,4 +13,8 @@ bp_api_v1 = Blueprint("api_v1", __name__)
 @bp_api_v1.get("/health")
 def health() -> tuple[Response, int]:
     """Endpoint de healthcheck usado por Render."""
-    return jsonify(status="ok"), 200
+    try:
+        db.session.execute(text("SELECT 1 FROM users LIMIT 1"))
+        return jsonify(status="ok", db="users:ready"), 200
+    except Exception:
+        return jsonify(status="ok", db="users:missing"), 200

--- a/app/scripts/db_upgrade.py
+++ b/app/scripts/db_upgrade.py
@@ -6,7 +6,7 @@ from app import create_app
 
 
 def main() -> None:
-    app = create_app()
+    app = create_app("default")
     with app.app_context():
         upgrade()
 


### PR DESCRIPTION
## Summary
- default BaseConfig to store the SQLite database in DATA_DIR/app.db and reuse safe engine options
- ensure create_app() creates the persistent DATA_DIR and logs the database URI for Render deployments
- add an API health endpoint that checks the users table and align the migration script with the runtime config

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb47bdf1848326a072886c9372698a