### PR TITLE
Align SQLite configuration with Render deployment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,14 @@ import os
 from pathlib import Path
 
 
+BASE_DIR = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = BASE_DIR.parent
+INSTANCE_DIR = PROJECT_ROOT / "instance"
+INSTANCE_DIR.mkdir(parents=True, exist_ok=True)
+DEFAULT_SQLITE = INSTANCE_DIR / "sgc.db"
+DEFAULT_SQLITE_URL = f"sqlite:///{DEFAULT_SQLITE}"
+
+
 class BaseConfig:
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret")
     SECURITY_PASSWORD_SALT = os.environ.get("SECURITY_PASSWORD_SALT", "dev-salt")
@@ -15,12 +23,11 @@ class BaseConfig:
     MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", "")
     MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER", "no-reply@codex.local")
     # Directorio de datos persistente (Render)
-    DATA_DIR = os.getenv("DATA_DIR", "/opt/render/project/src/data")
+    DATA_DIR = os.getenv("DATA_DIR", str(PROJECT_ROOT / "data"))
     # Construye la URI de SQLite si no hay DATABASE_URL (Postgres)
-    SQLITE_PATH = Path(DATA_DIR) / "app.db"
     SQLALCHEMY_DATABASE_URI = os.getenv(
         "DATABASE_URL",
-        f"sqlite:///{SQLITE_PATH}",
+        DEFAULT_SQLITE_URL,
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     # Estabilidad de conexiones

--- a/app/scripts/create_admin.py
+++ b/app/scripts/create_admin.py
@@ -8,7 +8,12 @@ def main():
     with app.app_context():
         u = User.query.filter_by(username="admin").first()
         if not u:
-            u = User(username="admin", email=None, is_admin=True, is_active=True)
+            u = User(
+                username="admin",
+                email=None,
+                is_admin=True,
+                is_active=True,
+            )
             u.set_password("admin123")
             db.session.add(u)
             db.session.commit()

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,108 +1,48 @@
-import logging
+from __future__ import with_statement
+
 from logging.config import fileConfig
 
-from flask import current_app
-
 from alembic import context
+from flask import current_app
+from sqlalchemy import engine_from_config, pool
 
-# this is the Alembic Config object, which provides
-# access to the values within the .ini file in use.
+# Configuración de logging de Alembic (opcional)
 config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-fileConfig(config.config_file_name)
-logger = logging.getLogger('alembic.env')
-
-
-def get_engine():
-    try:
-        # this works with Flask-SQLAlchemy<3 and Alchemical
-        return current_app.extensions['migrate'].db.get_engine()
-    except (TypeError, AttributeError):
-        # this works with Flask-SQLAlchemy>=3
-        return current_app.extensions['migrate'].db.engine
-
-
-def get_engine_url():
-    try:
-        return get_engine().url.render_as_string(hide_password=False).replace(
-            '%', '%%')
-    except AttributeError:
-        return str(get_engine().url).replace('%', '%%')
-
-
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-config.set_main_option('sqlalchemy.url', get_engine_url())
-target_db = current_app.extensions['migrate'].db
-
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
-
-
-def get_metadata():
-    if hasattr(target_db, 'metadatas'):
-        return target_db.metadatas[None]
-    return target_db.metadata
+# >>> AQUI Forzamos a usar el mismo URI que usa Flask <<<
+target_metadata = current_app.extensions["migrate"].db.metadata
+config.set_main_option("sqlalchemy.url", current_app.config["SQLALCHEMY_DATABASE_URI"])
 
 
 def run_migrations_offline():
-    """Run migrations in 'offline' mode.
-
-    This configures the context with just a URL
-    and not an Engine, though an Engine is acceptable
-    here as well.  By skipping the Engine creation
-    we don't even need a DBAPI to be available.
-
-    Calls to context.execute() here emit the given string to the
-    script output.
-
-    """
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
-        url=url, target_metadata=get_metadata(), literal_binds=True
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        render_as_batch=True,   # IMPORTANTE para SQLite
     )
-
     with context.begin_transaction():
         context.run_migrations()
 
 
 def run_migrations_online():
-    """Run migrations in 'online' mode.
-
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
-
-    # this callback is used to prevent an auto-migration from being generated
-    # when there are no changes to the schema
-    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
-    def process_revision_directives(context, revision, directives):
-        if getattr(config.cmd_opts, 'autogenerate', False):
-            script = directives[0]
-            if script.upgrade_ops.is_empty():
-                directives[:] = []
-                logger.info('No changes in schema detected.')
-
-    conf_args = current_app.extensions['migrate'].configure_args
-    if conf_args.get("process_revision_directives") is None:
-        conf_args["process_revision_directives"] = process_revision_directives
-
-    connectable = get_engine()
-
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
-            target_metadata=get_metadata(),
-            **conf_args
+            target_metadata=target_metadata,
+            compare_type=True,
+            render_as_batch=True,   # IMPORTANTE para SQLite
         )
-
         with context.begin_transaction():
             context.run_migrations()
 


### PR DESCRIPTION
## Summary
- ensure the default SQLite database path points to `instance/sgc.db` and create the instance directory when loading config
- configure Alembic to reuse Flask's database URI and enable `render_as_batch` for SQLite migrations
- adjust the admin bootstrap script formatting used during pre-deploy setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb85d3115c8326814086dc9a69bc25