### PR TITLE
Add simple auth mode toggle and decorator

### DIFF
--- a/app/authz.py
+++ b/app/authz.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from functools import wraps
+
+from flask import current_app, redirect, request, session, url_for
+
+
+def login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if current_app.config.get("AUTH_SIMPLE", False):
+            return view(*args, **kwargs)
+
+        if session.get("user"):
+            return view(*args, **kwargs)
+
+        return redirect(url_for("auth.login", next=request.path))
+
+    return wrapped
+

--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 import re
 
-from flask import current_app, render_template, request, redirect, url_for, flash
-from flask_login import current_user, login_required
+from flask import current_app, flash, redirect, render_template, request, session, url_for
+from flask_login import current_user
 
 from app.db import db
 from app.models.user import User
 from app.security import generate_reset_token
+
+from app.authz import login_required
 
 from . import bp_admin
 
@@ -42,7 +44,11 @@ def list_files():
 
 
 def admin_required() -> bool:
-    return current_user.is_authenticated and current_user.is_admin
+    session_user = session.get("user")
+    if session_user:
+        return bool(session_user.get("is_admin"))
+
+    return current_user.is_authenticated and getattr(current_user, "is_admin", False)
 
 
 @bp_admin.get("/users/new")

--- a/app/blueprints/folders/routes.py
+++ b/app/blueprints/folders/routes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from flask import flash, redirect, render_template, request, url_for
-from flask_login import login_required
+
+from app.authz import login_required
 
 from app.db import db
 from app.models.folder import Folder

--- a/app/config.py
+++ b/app/config.py
@@ -4,9 +4,17 @@ import os
 from pathlib import Path
 
 
+def env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value == "1"
+
+
 class BaseConfig:
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret")
     SECURITY_PASSWORD_SALT = os.environ.get("SECURITY_PASSWORD_SALT", "dev-salt")
+    AUTH_SIMPLE = env_flag("AUTH_SIMPLE", default=False)
     # Email opcional (si no se configura, se enviará a logs)
     MAIL_SERVER = os.environ.get("MAIL_SERVER", "")
     MAIL_PORT = int(os.environ.get("MAIL_PORT", 587 or 25))
@@ -37,6 +45,7 @@ class BaseConfig:
 
 class DevConfig(BaseConfig):
     DEBUG = True
+    AUTH_SIMPLE = env_flag("AUTH_SIMPLE", default=True)
 
 
 class ProdConfig(BaseConfig):


### PR DESCRIPTION
## Summary
- add an AUTH_SIMPLE flag with sensible defaults to the configuration
- create a flexible login_required decorator that bypasses checks when AUTH_SIMPLE is enabled
- update authentication and admin views to support session-based simple mode credentials while keeping existing flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb9d97c4d083268443a12c72ebe727