### PR TITLE
Resolve config merge conflict with env overrides

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,7 +13,8 @@ DEFAULT_SQLITE_URL = f"sqlite:///{DEFAULT_SQLITE}"
 
 
 class BaseConfig:
-    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret")
+    SECRET_KEY = os.getenv("SECRET_KEY", "superseguro")
+    DEBUG = os.getenv("DEBUG", "False").lower() == "true"
     SECURITY_PASSWORD_SALT = os.environ.get("SECURITY_PASSWORD_SALT", "dev-salt")
     # Email opcional (si no se configura, se enviará a logs)
     MAIL_SERVER = os.environ.get("MAIL_SERVER", "")
@@ -43,11 +44,11 @@ class BaseConfig:
 
 
 class DevConfig(BaseConfig):
-    DEBUG = True
+    DEBUG = os.getenv("DEBUG", "True").lower() == "true"
 
 
 class ProdConfig(BaseConfig):
-    DEBUG = False
+    DEBUG = os.getenv("DEBUG", "False").lower() == "true"
 
 
 class TestingConfig(BaseConfig):


### PR DESCRIPTION
## Summary
- allow the configuration DEBUG flag to be overridden via environment variables while keeping sensible defaults per environment
- default the shared SECRET_KEY to the resolved value from the environment, matching the intended merge resolution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc1191f0bc8326b8ca816f261e09a7