### PR TITLE
Add registration link to login and navbar

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,7 +50,7 @@ def create_app(config_name: str | None = None) -> Flask:
             has_web_index = "web.index" in app.view_functions
         except Exception:
             has_web_index = False
-        return {"has_web_index": has_web_index}
+        return {"has_web_index": has_web_index, "config": app.config}
 
     # Blueprints
     from . import models  # noqa: F401

--- a/app/blueprints/auth/templates/auth/login.html
+++ b/app/blueprints/auth/templates/auth/login.html
@@ -14,8 +14,8 @@
     </label>
     <button type="submit">Entrar</button>
   </form>
-  <p class="mt-3">
-    <a href="{{ url_for('auth.register') }}">Crear usuario</a>
-  </p>
+  <div class="mt-3 text-center">
+    <a href="{{ url_for('auth.register') }}">¿No tienes cuenta? Crear usuario</a>
+  </div>
 </article>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,6 +46,14 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('auth.login') }}">Entrar</a>
             </li>
+            {% if config.get('AUTH_SIMPLE', True) %}
+              <li class="nav-item">
+                <a class="btn btn-sm btn-outline-secondary ms-lg-3 mt-3 mt-lg-0"
+                   href="{{ url_for('auth.register') }}">
+                  Crear usuario
+                </a>
+              </li>
+            {% endif %}
             <li class="nav-item">
               <a class="btn btn-outline-primary ms-lg-3" href="{{ url_for('admin.index') }}">Panel Admin</a>
             </li>


### PR DESCRIPTION
## Summary
- add a prominent registration link on the login form
- expose the Flask config to templates to support conditional UI
- show a "Crear usuario" shortcut in the navbar when AUTH_SIMPLE is enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccc14258008326b30a82d41562d23c