### PR TITLE
Add registration endpoint to auth blueprint

### DIFF
--- a/app/blueprints/auth/templates/auth/register.html
+++ b/app/blueprints/auth/templates/auth/register.html
@@ -1,49 +1,31 @@
 {% extends "base.html" %}
-{% block title %}Crear usuario{% endblock %}
+{% block title %}Crear usuario - SGC{% endblock %}
+
 {% block content %}
-<div class="container" style="max-width:540px;margin:2rem auto;">
-  <div class="card shadow-sm">
-    <div class="card-body">
-      <h3 class="mb-3">Crear usuario</h3>
+<div class="container py-4">
+  <h1>Crear un nuevo usuario</h1>
+  <p class="text-muted">Solo usuario y contraseña, sin correo.</p>
 
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          <div class="mb-3">
-            {% for category, msg in messages %}
-              <div class="alert alert-{{ 'warning' if category=='warning' else category }}">{{ msg }}</div>
-            {% endfor %}
-          </div>
-        {% endif %}
-      {% endwith %}
-
-      <form method="post" novalidate>
-        <div class="mb-3">
-          <label class="form-label">Usuario</label>
-          <input class="form-control" type="text" name="username" required minlength="3" autofocus>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Contraseña</label>
-          <input class="form-control" type="password" name="password" required minlength="4">
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Confirmar contraseña</label>
-          <input class="form-control" type="password" name="confirm" required minlength="4">
-        </div>
-
-        {% if is_admin %}
-        <div class="form-check mb-3">
-          <input class="form-check-input" type="checkbox" id="is_admin" name="is_admin">
-          <label class="form-check-label" for="is_admin">Conceder rol administrador</label>
-        </div>
-        {% endif %}
-
-        <button class="btn btn-primary w-100" type="submit">Crear</button>
-      </form>
-
-      <div class="mt-3 text-center">
-        <a href="{{ url_for('auth.login') }}">¿Ya tienes cuenta? Inicia sesión</a>
-      </div>
+  <form method="post" action="{{ url_for('auth.register_post') }}" class="mt-3" style="max-width: 420px;">
+    <div class="mb-3">
+      <label class="form-label">Usuario</label>
+      <input type="text" name="username" class="form-control" required autofocus>
     </div>
-  </div>
+
+    <div class="mb-3">
+      <label class="form-label">Contraseña</label>
+      <input type="password" name="password" class="form-control" required>
+    </div>
+
+    <div class="mb-3">
+      <label class="form-label">Confirmar contraseña</label>
+      <input type="password" name="confirm" class="form-control" required>
+    </div>
+
+    <button type="submit" class="btn btn-primary btn-lg">
+      Crear usuario
+    </button>
+    <a href="{{ url_for('auth.login') }}" class="btn btn-link">Volver al login</a>
+  </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add GET/POST registration endpoints in the auth blueprint that create users in the database and surface validation feedback
- create the registration template that posts to the new endpoint and links back to login

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd139b92088326bb10768bbd79d4f8