### PR TITLE
Update home page buttons to highlight NOM resources

### DIFF
--- a/app/static/css/sgc.css
+++ b/app/static/css/sgc.css
@@ -27,3 +27,32 @@ footer a:hover {
   color: white;
   transform: scale(1.05);
 }
+
+.btn-group-nom {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+}
+
+.btn-group-nom a {
+  padding: 0.75rem 1rem;
+  border: 1px solid #2563eb;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: 500;
+  color: #2563eb;
+  transition: all 0.2s;
+}
+
+.btn-group-nom a:hover {
+  background-color: #2563eb;
+  color: #fff;
+}
+
+.btn-group-nom p {
+  margin: 0.25rem 0 0.75rem 0;
+  font-size: 0.9rem;
+  color: #555;
+}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -11,9 +11,26 @@
           Plataforma centralizada para Huasteca Fuel Terminal, enfocada en la gestión de proyectos
           de Gas Natural con trazabilidad completa de reportes, bitácoras y control de carpetas.
         </p>
-        <div class="d-flex flex-wrap gap-2 mt-3">
-          <a class="btn btn-primary btn-lg" href="{{ url_for('auth.login') }}">Login</a>
-          <a class="btn btn-outline-secondary btn-lg" href="{{ url_for('admin.index') }}">Panel Admin</a>
+        <div class="btn-group-nom">
+          <a class="btn btn-outline" target="_blank" href="https://www.gob.mx/stps">
+            NOM-STPS: Seguridad y Salud en el Trabajo
+          </a>
+          <p>Protección del personal en la operación de la draga, maquinaria pesada y trabajos en tierra.</p>
+
+          <a class="btn btn-outline" target="_blank" href="https://www.gob.mx/semarnat">
+            NOM-SEMARNAT: Medio Ambiente
+          </a>
+          <p>Gestión de RP y RSU, normas de ruido, emisiones y disposición de material dragado.</p>
+
+          <a class="btn btn-outline" target="_blank" href="https://www.gob.mx/sct">
+            NOM-SCT: Transporte y Maquinaria
+          </a>
+          <p>Regulación del uso de maquinaria pesada y equipos de carga en obra terrestre.</p>
+
+          <a class="btn btn-outline" target="_blank" href="https://www.dof.gob.mx/">
+            Diario Oficial de la Federación (DOF)
+          </a>
+          <p>Publicación oficial de todas las NOM vigentes aplicables a la obra de dragado.</p>
         </div>
       </div>
       <div class="col-lg-5 text-center">


### PR DESCRIPTION
## Summary
- replace the home page landing buttons with four external NOM resource links and supporting descriptions
- add custom styling for the new NOM resource button group in sgc.css

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5130a5e08326a1add5f4592500fd