### PR TITLE
Replace landing buttons with NOM links

### DIFF
--- a/app/blueprints/web/templates/web/index.html
+++ b/app/blueprints/web/templates/web/index.html
@@ -13,9 +13,52 @@
           Integrado con cobertura de código y CI/CD, listo para crecer con tus
           necesidades.
         </p>
-        <div class="d-flex gap-2 mt-3">
-          <a class="btn btn-primary btn-lg" href="{{ url_for('auth.login') }}">Entrar</a>
-          <a class="btn btn-outline-secondary btn-lg" href="{{ url_for('admin.index') }}">Panel Admin</a>
+        <div class="nom-section mt-4">
+          <div class="nom-card">
+            <h3>⚒️ NOM-STPS</h3>
+            <p>
+              <b>Seguridad y Salud en el Trabajo</b><br />
+              Aplica en la operación de la draga, maquinaria pesada y trabajos en tierra.
+            </p>
+            <a class="btn-nom" target="_blank" href="https://www.gob.mx/stps"
+              >Ver NOM-STPS</a
+            >
+          </div>
+
+          <div class="nom-card">
+            <h3>🌱 NOM-SEMARNAT</h3>
+            <p>
+              <b>Medio Ambiente</b><br />
+              Gestión de RP y RSU, normas de ruido, emisiones y disposición de material
+              dragado.
+            </p>
+            <a class="btn-nom" target="_blank" href="https://www.gob.mx/semarnat"
+              >Ver NOM-SEMARNAT</a
+            >
+          </div>
+
+          <div class="nom-card">
+            <h3>🚜 NOM-SCT</h3>
+            <p>
+              <b>Transporte y Maquinaria</b><br />
+              Regula maquinaria pesada y equipos de carga en obra terrestre.
+            </p>
+            <a class="btn-nom" target="_blank" href="https://www.gob.mx/sct"
+              >Ver NOM-SCT</a
+            >
+          </div>
+
+          <div class="nom-card">
+            <h3>📜 DOF</h3>
+            <p>
+              <b>Diario Oficial de la Federación</b><br />
+              Publicación oficial de todas las NOM vigentes aplicables a la obra de
+              dragado.
+            </p>
+            <a class="btn-nom" target="_blank" href="https://www.dof.gob.mx/"
+              >Ir al DOF</a
+            >
+          </div>
         </div>
       </div>
       <div class="col-md-5 text-center">

--- a/app/static/css/sgc.css
+++ b/app/static/css/sgc.css
@@ -56,3 +56,50 @@ footer a:hover {
   font-size: 0.9rem;
   color: #555;
 }
+
+.nom-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.nom-card {
+  background: #ffffff;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.nom-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.15);
+}
+
+.nom-card h3 {
+  font-size: 1.3rem;
+  margin-bottom: 0.5rem;
+}
+
+.nom-card p {
+  font-size: 0.95rem;
+  color: #444;
+  margin-bottom: 1rem;
+}
+
+.btn-nom {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: #007bff;
+  color: white;
+  border-radius: 6px;
+  text-decoration: none;
+  font-weight: bold;
+  transition: background 0.2s;
+}
+
+.btn-nom:hover {
+  background: #0056b3;
+}


### PR DESCRIPTION
## Summary
- replace the landing page login and admin buttons with a set of NOM information cards and external links
- add styling for the NOM cards and buttons in the shared sgc stylesheet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd532335108326b29e5be762b18a12