### PR TITLE
Add NOM resources section to landing page

### DIFF
--- a/app/blueprints/web/templates/web/index.html
+++ b/app/blueprints/web/templates/web/index.html
@@ -13,10 +13,6 @@
           Integrado con cobertura de código y CI/CD, listo para crecer con tus
           necesidades.
         </p>
-        <div class="d-flex gap-2 mt-3">
-          <a class="btn btn-primary btn-lg" href="{{ url_for('auth.login') }}">Entrar</a>
-          <a class="btn btn-outline-secondary btn-lg" href="{{ url_for('admin.index') }}">Panel Admin</a>
-        </div>
       </div>
       <div class="col-md-5 text-center">
         <img
@@ -43,6 +39,45 @@
     </div>
   </div>
 </section>
+
+<section class="nom-intro">
+  <h2>📑 Normas aplicables a la obra de dragado</h2>
+  <p>
+    Estas Normas Oficiales Mexicanas (NOM) son las que impactan directamente en la
+    operación de dragado, seguridad del personal, uso de maquinaria pesada,
+    construcción de infraestructura y manejo ambiental.
+  </p>
+</section>
+
+<div class="nom-section">
+  <div class="nom-card">
+    <h3>⚒️ NOM-STPS</h3>
+    <p><b>Seguridad y Salud en el Trabajo</b><br>
+    Aplica en la operación de la draga, maquinaria pesada y trabajos en tierra.</p>
+    <a class="btn-nom" target="_blank" href="https://www.gob.mx/stps">Ver NOM-STPS</a>
+  </div>
+
+  <div class="nom-card">
+    <h3>🌱 NOM-SEMARNAT</h3>
+    <p><b>Medio Ambiente</b><br>
+    Gestión de RP y RSU, normas de ruido, emisiones y disposición de material dragado.</p>
+    <a class="btn-nom" target="_blank" href="https://www.gob.mx/semarnat">Ver NOM-SEMARNAT</a>
+  </div>
+
+  <div class="nom-card">
+    <h3>🚜 NOM-SCT</h3>
+    <p><b>Transporte y Maquinaria</b><br>
+    Regula maquinaria pesada y equipos de carga en obra terrestre.</p>
+    <a class="btn-nom" target="_blank" href="https://www.gob.mx/sct">Ver NOM-SCT</a>
+  </div>
+
+  <div class="nom-card">
+    <h3>📜 DOF</h3>
+    <p><b>Diario Oficial de la Federación</b><br>
+    Publicación oficial de todas las NOM vigentes aplicables a la obra de dragado.</p>
+    <a class="btn-nom" target="_blank" href="https://www.dof.gob.mx/">Ir al DOF</a>
+  </div>
+</div>
 
 <section class="py-5">
   <div class="container">

--- a/app/static/css/sgc.css
+++ b/app/static/css/sgc.css
@@ -56,3 +56,74 @@ footer a:hover {
   font-size: 0.9rem;
   color: #555;
 }
+
+.nom-intro {
+  margin-top: 2rem;
+  text-align: center;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.nom-intro h2 {
+  font-size: 1.8rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.nom-intro p {
+  font-size: 1rem;
+  color: #555;
+}
+
+.nom-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin: 2.5rem auto 0;
+  max-width: 1100px;
+  padding: 0 1.5rem;
+}
+
+.nom-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.75rem;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nom-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 35px rgba(15, 23, 42, 0.12);
+}
+
+.nom-card h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.nom-card p {
+  font-size: 0.95rem;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.btn-nom {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+  border: 1px solid #2563eb;
+  color: #2563eb;
+  transition: all 0.2s ease;
+}
+
+.btn-nom:hover {
+  background-color: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
+}


### PR DESCRIPTION
## Summary
- replace the old login/admin call-to-action on the landing page with a NOM introduction and resource links
- style the new NOM section with grid cards and link buttons for each applicable standard

## Testing
- not run (HTML/CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd543dc9b88326a19f4042df5ff82b