### PR TITLE
Add admin checklists and improved dashboard layout

### DIFF
--- a/app/blueprints/admin/templates/admin/_base_admin.html
+++ b/app/blueprints/admin/templates/admin/_base_admin.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}{% block admin_title %}SGC · Admin{% endblock %}{% endblock %}
+{% block content %}
+<div class="admin-layout">
+  <aside class="admin-sidebar">
+    <div class="brand">SGC · Admin</div>
+    <nav>
+      <a href="{{ url_for('admin.index') }}">📊 Dashboard</a>
+      <a href="{{ url_for('admin.projects') }}">🏗️ Proyectos</a>
+      <a href="{{ url_for('admin.bitacoras') }}">📝 Bitácoras</a>
+      <a href="{{ url_for('admin.checklists') }}">✅ Checklists</a>
+    </nav>
+  </aside>
+  <main class="admin-main">
+    {% block admin_content %}{% endblock %}
+  </main>
+</div>
+{% endblock %}

--- a/app/blueprints/admin/templates/admin/bitacoras.html
+++ b/app/blueprints/admin/templates/admin/bitacoras.html
@@ -1,0 +1,30 @@
+{% extends "admin/_base_admin.html" %}
+{% block admin_title %}Bitácoras · Admin · SGC{% endblock %}
+{% block admin_content %}
+<h1>Bitácoras</h1>
+
+<form class="row g-2 mb-3" method="post" action="{{ url_for('admin.bitacoras_create') }}" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:.5rem">
+  <select class="form-select" name="project_id" required>
+    <option value="">Proyecto…</option>
+    {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
+  </select>
+  <input class="form-control" name="author" placeholder="Autor (opcional)">
+  <input class="form-control" name="date" type="date" value="{{ (now or none)|default('', true) }}">
+  <textarea class="form-control" name="text" placeholder="Descripción..." style="grid-column:1/-1" required></textarea>
+  <div><button class="btn btn-primary">Guardar bitácora</button></div>
+</form>
+
+<table class="table">
+  <thead><tr><th>Fecha</th><th>Proyecto</th><th>Autor</th><th>Texto</th></tr></thead>
+  <tbody>
+    {% for b in logs %}
+    <tr>
+      <td>{{ b.date }}</td>
+      <td>{{ b.project.name }}</td>
+      <td>{{ b.author or "-" }}</td>
+      <td>{{ b.text[:140] }}{% if b.text|length>140 %}…{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/blueprints/admin/templates/admin/checklist_detail.html
+++ b/app/blueprints/admin/templates/admin/checklist_detail.html
@@ -1,0 +1,24 @@
+{% extends "admin/_base_admin.html" %}
+{% block admin_title %}Checklist · Admin · SGC{% endblock %}
+{% block admin_content %}
+<h1>Checklist — {{ c.project.name }} ({{ c.date }})</h1>
+<p>Estado: <span class="badge">{{ c.status }}</span> · Creado por: {{ c.created_by or "-" }}</p>
+
+<form method="post" action="{{ url_for('admin.checklist_toggle', checklist_id=c.id) }}">
+  <table class="table">
+    <thead><tr><th>Hecho</th><th>Ítem</th></tr></thead>
+    <tbody>
+      {% for it in c.items %}
+      <tr>
+        <td style="width:120px">
+          <button name="item_id" value="{{ it.id }}" class="btn btn-outline">
+            {% if it.done %}✔️{% else %}—{% endif %}
+          </button>
+        </td>
+        <td>{{ it.text }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</form>
+{% endblock %}

--- a/app/blueprints/admin/templates/admin/checklists.html
+++ b/app/blueprints/admin/templates/admin/checklists.html
@@ -1,0 +1,53 @@
+{% extends "admin/_base_admin.html" %}
+{% block admin_title %}Checklists · Admin · SGC{% endblock %}
+{% block admin_content %}
+<h1>Checklists</h1>
+
+<h3 class="mt-2">Plantillas</h3>
+<form class="row g-2 mb-3" method="post" action="{{ url_for('admin.checklist_template_create') }}" style="display:grid;grid-template-columns:1fr 1fr auto;gap:.5rem;max-width:900px">
+  <input class="form-control" name="name" placeholder="Nombre de la plantilla (ej. Checklist diario de dragado)" required>
+  <select class="form-select" name="project_id">
+    <option value="">(Opcional) Proyecto específico</option>
+    {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
+  </select>
+  <button class="btn btn-primary">Crear plantilla</button>
+</form>
+
+<ul>
+  {% for t in templates %}
+    <li>{{ t.name }} {% if t.project_id %} — <span class="badge">Proyecto: {{ t.project.name }}</span>{% endif %} ({{ t.items|length }} ítems)</li>
+  {% endfor %}
+</ul>
+
+<hr>
+
+<h3 class="mt-2">Checklist diario</h3>
+<form class="row g-2 mb-3" method="post" action="{{ url_for('admin.checklist_daily_create') }}" style="display:grid;grid-template-columns:1fr 1fr 1fr auto;gap:.5rem;max-width:900px">
+  <select class="form-select" name="project_id" required>
+    <option value="">Proyecto…</option>
+    {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
+  </select>
+  <select class="form-select" name="template_id" required>
+    <option value="">Plantilla…</option>
+    {% for t in templates %}<option value="{{ t.id }}">{{ t.name }}</option>{% endfor %}
+  </select>
+  <input class="form-control" type="date" name="date" value="">
+  <input class="form-control" name="created_by" placeholder="Creado por (opcional)">
+  <button class="btn btn-primary" style="grid-column:1/-1;max-width:220px">Crear checklist</button>
+</form>
+
+<h4>Recientes</h4>
+<table class="table">
+  <thead><tr><th>Fecha</th><th>Proyecto</th><th>Estado</th><th></th></tr></thead>
+  <tbody>
+    {% for c in recientes %}
+    <tr>
+      <td>{{ c.date }}</td>
+      <td>{{ c.project.name }}</td>
+      <td><span class="badge">{{ c.status }}</span></td>
+      <td><a class="btn btn-outline" href="{{ url_for('admin.checklist_detail', checklist_id=c.id) }}">Abrir</a></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/blueprints/admin/templates/admin/index.html
+++ b/app/blueprints/admin/templates/admin/index.html
@@ -1,78 +1,38 @@
-{% extends "base.html" %}
-{% block title %}Dashboard – SGC{% endblock %}
-{% block content %}
-<div class="container py-4">
-  <h1 class="mb-3">Dashboard SGC</h1>
-
-  <div class="row g-3">
-    <div class="col-md-3">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <div class="fw-bold text-muted">Proyectos</div>
-          <div class="fs-3">{{ total_projects }}</div>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-3">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <div class="fw-bold text-muted">Avance promedio</div>
-          <div class="fs-3">{{ avg_progress }}%</div>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-3">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <div class="fw-bold text-muted">Presupuesto</div>
-          <div class="fs-5">${{ "{:,.0f}".format(budget) }}</div>
-        </div>
-      </div>
-    </div>
-
-    <div class="col-md-3">
-      <div class="card shadow-sm">
-        <div class="card-body">
-          <div class="fw-bold text-muted">Gastado</div>
-          <div class="fs-5">${{ "{:,.0f}".format(spent) }}</div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  {% if main_project %}
-  <div class="mt-4">
-    <h5>{{ main_project.name }} — KPIs últimos 30 días</h5>
-    <canvas id="kpiChart" height="90"></canvas>
-  </div>
-  {% endif %}
+{% extends "admin/_base_admin.html" %}
+{% block admin_title %}Dashboard · Admin · SGC{% endblock %}
+{% block admin_content %}
+<h1>Dashboard SGC</h1>
+<div class="row g-3" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem">
+  <div class="card"><div class="card-body">
+    <div class="fw-bold text-muted">Proyectos</div>
+    <div class="fs-3">{{ total_projects }}</div>
+  </div></div>
+  <div class="card"><div class="card-body">
+    <div class="fw-bold text-muted">Avance promedio</div>
+    <div class="fs-3">{{ avg_progress }}%</div>
+  </div></div>
+  <div class="card"><div class="card-body">
+    <div class="fw-bold text-muted">Presupuesto</div>
+    <div class="fs-5">${{ "{:,.0f}".format(budget) }}</div>
+  </div></div>
+  <div class="card"><div class="card-body">
+    <div class="fw-bold text-muted">Gastado</div>
+    <div class="fs-5">${{ "{:,.0f}".format(spent) }}</div>
+  </div></div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-{% if main_project %}
-<script>
-(async function(){
-  const res = await fetch("{{ url_for('admin.kpi_json', project_id=main_project.id) }}");
-  const data = await res.json();
-  const ctx = document.getElementById('kpiChart');
-  new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: data.labels,
-      datasets: [
-        { label: 'Progreso (%)', data: data.progreso, borderWidth: 2 },
-        { label: 'Gasto (MXN)', data: data.gasto, borderWidth: 2 }
-      ]
-    },
-    options: {
-      responsive: true,
-      interaction: { mode: 'index', intersect: false },
-      scales: { y: { beginAtZero: true } }
-    }
-  });
-})();
-</script>
-{% endif %}
+<h3 class="mt-4">Últimas bitácoras</h3>
+<table class="table">
+  <thead><tr><th>Fecha</th><th>Proyecto</th><th>Autor</th><th>Texto</th></tr></thead>
+  <tbody>
+    {% for b in ultimas %}
+    <tr>
+      <td>{{ b.date }}</td>
+      <td>{{ b.project.name }}</td>
+      <td>{{ b.author or "-" }}</td>
+      <td>{{ b.text[:120] }}{% if b.text|length>120 %}…{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/app/blueprints/admin/templates/admin/projects.html
+++ b/app/blueprints/admin/templates/admin/projects.html
@@ -1,0 +1,25 @@
+{% extends "admin/_base_admin.html" %}
+{% block admin_title %}Proyectos · Admin · SGC{% endblock %}
+{% block admin_content %}
+<h1>Proyectos</h1>
+
+<form class="row g-2 mb-3" method="post" action="{{ url_for('admin.projects_create') }}" style="display:grid;grid-template-columns:1fr 1fr auto;gap:.5rem;max-width:800px">
+  <input class="form-control" name="name" placeholder="Nombre del proyecto" required>
+  <input class="form-control" name="client" placeholder="Cliente (opcional)">
+  <button class="btn btn-primary">Crear</button>
+</form>
+
+<table class="table">
+  <thead><tr><th>Nombre</th><th>Cliente</th><th>Progreso</th><th>Estado</th></tr></thead>
+  <tbody>
+    {% for p in projects %}
+    <tr>
+      <td>{{ p.name }}</td>
+      <td>{{ p.client or "-" }}</td>
+      <td>{{ p.progress }}%</td>
+      <td><span class="badge">{{ p.status }}</span></td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/models.py
+++ b/app/models.py
@@ -31,6 +31,10 @@ class Project(db.Model):
     reports = db.relationship("Report", backref="project", lazy=True)
     logs = db.relationship("Bitacora", backref="project", lazy=True)
     metrics = db.relationship("MetricDaily", backref="project", lazy=True)
+    checklist_templates = db.relationship(
+        "ChecklistTemplate", backref="project", lazy=True
+    )
+    daily_checklists = db.relationship("DailyChecklist", backref="project", lazy=True)
 
 
 class Folder(db.Model):
@@ -76,6 +80,51 @@ class MetricDaily(db.Model):
     date = db.Column(db.Date, nullable=False)
     value = db.Column(db.Float, nullable=False, default=0.0)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+# --- MODELOS DE CHECKLISTS ---
+class ChecklistTemplate(db.Model):
+    __tablename__ = "checklist_templates"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(160), nullable=False, unique=True)
+    project_id = db.Column(db.Integer, db.ForeignKey("projects.id"), nullable=True)
+    items = db.relationship(
+        "ChecklistTemplateItem", backref="template", cascade="all,delete-orphan"
+    )
+
+
+class ChecklistTemplateItem(db.Model):
+    __tablename__ = "checklist_template_items"
+    id = db.Column(db.Integer, primary_key=True)
+    template_id = db.Column(
+        db.Integer, db.ForeignKey("checklist_templates.id"), nullable=False
+    )
+    text = db.Column(db.String(255), nullable=False)
+    order = db.Column(db.Integer, default=0)
+
+
+class DailyChecklist(db.Model):
+    __tablename__ = "daily_checklists"
+    id = db.Column(db.Integer, primary_key=True)
+    project_id = db.Column(db.Integer, db.ForeignKey("projects.id"), nullable=False)
+    date = db.Column(db.Date, nullable=False)
+    created_by = db.Column(db.String(80))
+    status = db.Column(
+        db.String(20), default="en_progreso"
+    )  # en_progreso / completo
+    items = db.relationship(
+        "DailyChecklistItem", backref="checklist", cascade="all,delete-orphan"
+    )
+
+
+class DailyChecklistItem(db.Model):
+    __tablename__ = "daily_checklist_items"
+    id = db.Column(db.Integer, primary_key=True)
+    checklist_id = db.Column(
+        db.Integer, db.ForeignKey("daily_checklists.id"), nullable=False
+    )
+    text = db.Column(db.String(255), nullable=False)
+    done = db.Column(db.Boolean, default=False)
 
 
 class Todo(db.Model):
@@ -173,6 +222,10 @@ __all__ = [
     "Report",
     "Bitacora",
     "MetricDaily",
+    "ChecklistTemplate",
+    "ChecklistTemplateItem",
+    "DailyChecklist",
+    "DailyChecklistItem",
     "Todo",
     "User",
 ]

--- a/app/scripts/seed_demo.py
+++ b/app/scripts/seed_demo.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+from datetime import date
+from random import choice
+
 from app import create_app
 from app.db import db
-from app.models import User
+from app.models import (
+    Bitacora,
+    ChecklistTemplate,
+    ChecklistTemplateItem,
+    DailyChecklist,
+    DailyChecklistItem,
+    Project,
+    User,
+)
 
 
 def ensure_user(username: str, password: str, role: str, title: str | None = None):
@@ -18,6 +29,85 @@ def ensure_user(username: str, password: str, role: str, title: str | None = Non
         print(f"User already exists: {username} ({u.role})")
 
 
+def seed_admin_extra():
+    # Proyecto demo si no existe
+    project = Project.query.filter_by(name="Huasteca Fuel Terminal").first()
+    if not project:
+        project = Project(
+            name="Huasteca Fuel Terminal",
+            client="Gas Natural",
+            status="activo",
+            progress=42.0,
+            budget=3_500_000,
+            spent=1_250_000,
+        )
+        db.session.add(project)
+        db.session.commit()
+
+    # Plantilla demo
+    template = ChecklistTemplate.query.filter_by(
+        name="Checklist diario de dragado"
+    ).first()
+    if not template:
+        template = ChecklistTemplate(name="Checklist diario de dragado", project_id=project.id)
+        db.session.add(template)
+        db.session.commit()
+        base_items = [
+            "EPP completo",
+            "Señalización en tierra",
+            "Control de RP/RSU",
+            "Revisión de oleaje/clima",
+            "Mantenimiento básico draga",
+        ]
+        for order, text in enumerate(base_items):
+            db.session.add(
+                ChecklistTemplateItem(template_id=template.id, text=text, order=order)
+            )
+        db.session.commit()
+
+    # Checklist del día
+    if not DailyChecklist.query.filter_by(
+        project_id=project.id, date=date.today()
+    ).first():
+        checklist = DailyChecklist(
+            project_id=project.id,
+            date=date.today(),
+            created_by="admin",
+            status="en_progreso",
+        )
+        db.session.add(checklist)
+        db.session.commit()
+        items = (
+            ChecklistTemplateItem.query.filter_by(template_id=template.id)
+            .order_by(ChecklistTemplateItem.order)
+            .all()
+        )
+        for item in items:
+            db.session.add(
+                DailyChecklistItem(checklist_id=checklist.id, text=item.text, done=False)
+            )
+        db.session.commit()
+
+    # Bitácoras de ejemplo
+    if not Bitacora.query.first():
+        authors = ["sistema", "julia", "carlos"]
+        samples = [
+            "Inicio de actividades en frente norte. Señalización colocada.",
+            "Revisión de oleaje: operación con precaución. Sin incidentes.",
+            "Traslado de material dragado al sitio aprobado por SEMARNAT.",
+        ]
+        for text in samples:
+            db.session.add(
+                Bitacora(
+                    project_id=project.id,
+                    author=choice(authors),
+                    text=text,
+                    date=date.today(),
+                )
+            )
+        db.session.commit()
+
+
 def main():
     app = create_app()
     with app.app_context():
@@ -27,7 +117,8 @@ def main():
         ensure_user("sofia", "view123", "viewer", "Consulta")
 
         db.session.commit()
-        print("Seed done.")
+        seed_admin_extra()
+        print("Seed demo (usuarios + admin extra) listo.")
 
 
 if __name__ == "__main__":

--- a/app/static/css/sgc.css
+++ b/app/static/css/sgc.css
@@ -103,3 +103,12 @@ footer a:hover {
 .btn-nom:hover {
   background: #0056b3;
 }
+.admin-layout{display:grid;grid-template-columns:240px 1fr;min-height:70vh;gap:1rem}
+.admin-sidebar{border-right:1px solid #e5e7eb;padding:1rem}
+.admin-sidebar .brand{font-weight:700;margin-bottom:1rem}
+.admin-sidebar nav a{display:block;padding:.5rem .25rem;border-radius:.5rem;color:#111827;text-decoration:none}
+.admin-sidebar nav a:hover{background:#f3f4f6}
+.admin-main{padding:1rem}
+.table{width:100%;border-collapse:collapse}
+.table th,.table td{border-bottom:1px solid #eee;padding:.5rem .4rem;font-size:.95rem}
+.badge{display:inline-block;border:1px solid #e5e7eb;border-radius:999px;padding:.15rem .5rem;font-size:.8rem}


### PR DESCRIPTION
## Summary
- introduce checklist template and daily checklist models and seed data for demo content
- refresh admin dashboard layout with sidebar navigation and new project, bitacora, and checklist views
- update admin routes, styles, and seed script to support checklist workflows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd5e0b57d083269357dd84a77527e8