### PR TITLE
Normalize user emails and handle project duplicates

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -4,13 +4,24 @@ from datetime import datetime
 from typing import Any
 
 from flask_login import UserMixin
-from sqlalchemy import Boolean, Date, DateTime, Float, ForeignKey, Index, String, Text
+from sqlalchemy import (
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    event,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import expression
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from app.db import db
 from app.extensions import bcrypt, login_manager
+from app.utils.strings import normalize_email
 
 
 class Project(db.Model):
@@ -206,6 +217,16 @@ class User(db.Model, UserMixin):
 
     def __repr__(self) -> str:
         return f"<User {self.username}>"
+
+
+@event.listens_for(User, "before_insert", propagate=True)
+def _user_before_insert(mapper, connection, target):  # pragma: no cover - SQLAlchemy hook
+    target.email = normalize_email(target.email)
+
+
+@event.listens_for(User, "before_update", propagate=True)
+def _user_before_update(mapper, connection, target):  # pragma: no cover - SQLAlchemy hook
+    target.email = normalize_email(target.email)
 
 
 @login_manager.user_loader

--- a/app/utils/strings.py
+++ b/app/utils/strings.py
@@ -1,0 +1,16 @@
+"""Utility helpers for working with strings."""
+
+from __future__ import annotations
+
+
+def normalize_email(value: str | None) -> str | None:
+    """Return the email in a canonical form.
+
+    The function strips any leading or trailing whitespace and lowercases
+    the value so that comparisons can be made consistently regardless of
+    how the address was provided by the user.
+    """
+
+    if value is None:
+        return None
+    return value.strip().lower() or None

--- a/migrations/versions/20251005_normalize_user_emails.py
+++ b/migrations/versions/20251005_normalize_user_emails.py
@@ -1,0 +1,19 @@
+"""normalize stored user emails"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20251005_normalize_user_emails"
+down_revision = "20250918_add_role_title"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        sa.text("UPDATE users SET email = lower(trim(email)) WHERE email IS NOT NULL")
+    )
+
+
+def downgrade():
+    # No se puede restaurar la capitalización original de forma confiable.
+    pass

--- a/tests/admin/test_create_project_unique.py
+++ b/tests/admin/test_create_project_unique.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from app import create_app
+from app.db import db
+from app.models import User
+
+
+@pytest.fixture()
+def app_with_admin(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    app = create_app("test")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(
+            username="admin",
+            email="admin@example.com",
+            role="admin",
+            is_admin=True,
+        )
+        admin.set_password("admin12345")
+        db.session.add(admin)
+        db.session.commit()
+    yield app
+    with app.app_context():
+        db.drop_all()
+        db.session.remove()
+
+
+@pytest.fixture()
+def client(app_with_admin):
+    return app_with_admin.test_client()
+
+
+def login(client):
+    return client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "admin12345"},
+        follow_redirects=True,
+    )
+
+
+def test_create_project_duplicate_name_returns_409(client):
+    login(client)
+
+    r1 = client.post("/admin/projects", json={"name": "Dragado 2025"})
+    assert r1.status_code == 201
+    data1 = r1.get_json()
+    assert data1["ok"] is True
+    assert data1["project"]["name"] == "Dragado 2025"
+
+    r2 = client.post("/admin/projects", json={"name": "Dragado 2025"})
+    assert r2.status_code == 409
+    data2 = r2.get_json()
+    assert data2["ok"] is False
+    assert "Ya existe un proyecto" in data2["error"]
+
+    r3 = client.post("/admin/projects", json={"name": ""})
+    assert r3.status_code == 400
+    data3 = r3.get_json()
+    assert data3["ok"] is False
+    assert "obligatorio" in data3["error"].lower()

--- a/tests/auth/test_forgot_password_email_case.py
+++ b/tests/auth/test_forgot_password_email_case.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from app import create_app
+from app.db import db
+from app.models import User
+
+
+def setup_app():
+    app = create_app("test")
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(
+            username="demo",
+            email="user@example.com",
+            role="viewer",
+            is_admin=False,
+        )
+        user.set_password("demo12345")
+        db.session.add(user)
+        db.session.commit()
+        # Fuerza un email en mayúsculas como pudo haber quedado en producción
+        db.session.execute(
+            text("UPDATE users SET email = 'USER@EXAMPLE.COM' WHERE id = :id"),
+            {"id": user.id},
+        )
+        db.session.commit()
+    return app
+
+
+def test_forgot_password_normalizes_email_case_insensitive():
+    app = setup_app()
+    client = app.test_client()
+
+    response = client.post(
+        "/auth/forgot-password",
+        data={"email": "user@example.com"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"/auth/reset-password/" in response.data
+


### PR DESCRIPTION
## Summary
- add a shared email normalization helper and use it when persisting and querying users
- update admin project creation to surface friendly errors when names collide and add a migration to clean stored emails
- cover the new behaviours with regression tests for password reset lookups and duplicate projects

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd95c9bce48326b8aa7870052dd008