### PR TITLE
Fix Alembic CLI support and add seed-admin command

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from getpass import getpass
 
+import click
 from flask import current_app
 from werkzeug.security import generate_password_hash
 
@@ -72,5 +73,70 @@ def register_cli(app):
             return
 
         print(f"Admin creado: {user.email} ({user.username})")
+
+    @app.cli.command("seed-admin")
+    @click.option("--email", required=True, help="Email del administrador a crear")
+    @click.option(
+        "--password",
+        required=True,
+        help="Contraseña para el administrador (no se muestra en logs)",
+    )
+    @click.option(
+        "--username",
+        required=False,
+        help="Username opcional (por defecto se deriva del email)",
+    )
+    def seed_admin(email: str, password: str, username: str | None = None):
+        """Crear o asegurar la existencia de un admin de forma no interactiva."""
+
+        email_n = normalize_email(email)
+        if not email_n:
+            click.echo("Email inválido", err=True)
+            raise SystemExit(1)
+
+        if User.query.filter_by(email=email_n).first():
+            click.echo("Ya existe un usuario con ese email, nada por hacer.")
+            return
+
+        resolved_username = (username or email_n.split("@", 1)[0] or "admin").strip()
+        if User.query.filter_by(username=resolved_username).first():
+            click.echo(
+                "Ya existe un usuario con ese username; especifica otro con --username.",
+                err=True,
+            )
+            raise SystemExit(1)
+
+        user = User(
+            username=resolved_username,
+            email=email_n,
+            role="admin",
+            is_admin=True,
+            is_active=True,
+        )
+
+        if hasattr(user, "set_password"):
+            user.set_password(password)
+        elif hasattr(user, "password_hash"):
+            user.password_hash = generate_password_hash(password)
+        else:
+            click.echo(
+                "El modelo de usuario no soporta asignar contraseña de forma automática.",
+                err=True,
+            )
+            raise SystemExit(1)
+
+        if hasattr(user, "force_change_password"):
+            user.force_change_password = False
+
+        db.session.add(user)
+        try:
+            db.session.commit()
+        except Exception as exc:  # pragma: no cover - feedback interactivo
+            db.session.rollback()
+            current_app.logger.exception("No se pudo crear el admin", exc_info=exc)
+            click.echo("No se pudo crear el usuario administrador. Revisa los logs.", err=True)
+            raise SystemExit(1)
+
+        click.echo(f"Admin creado: {user.email} ({user.username})")
 
     return app

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,6 +1,7 @@
 # A generic, single database configuration.
 
 [alembic]
+script_location = migrations
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
 


### PR DESCRIPTION
## Summary
- configure Alembic so `alembic upgrade head` works by itself, loading the app context automatically
- add a `flask seed-admin` command for seeding an admin user non-interactively

## Testing
- `pytest`
- `alembic -c migrations/alembic.ini upgrade head`
- `FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123`


------
https://chatgpt.com/codex/tasks/task_e_68cdaa5dabe48326a1af107cc0ef47c3