### PR TITLE
Refactor landing layout and add public home blueprint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ from .blueprints.api.v1 import bp_api_v1
 from .blueprints.auth import bp_auth
 from .blueprints.ping import bp_ping
 from .blueprints.web import bp_web
+from .routes.public import public_bp
 from .config import get_config
 from .db import db
 from .extensions import csrf, init_auth_extensions, limiter
@@ -116,6 +117,7 @@ def create_app(config_name: str | None = None) -> Flask:
     from . import models  # noqa: F401
     from .api import v1 as _api_v1  # noqa: F401
 
+    app.register_blueprint(public_bp)
     app.register_blueprint(bp_auth)
     app.register_blueprint(bp_web)
     app.register_blueprint(bp_admin)

--- a/app/blueprints/web/__init__.py
+++ b/app/blueprints/web/__init__.py
@@ -9,7 +9,7 @@ bp_web = Blueprint(
 )
 
 
-@bp_web.get("/")
+@bp_web.get("/dashboard")
 def index():
     return render_template("home.html")
 

--- a/app/routes/public.py
+++ b/app/routes/public.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from flask import Blueprint, render_template
+
+public_bp = Blueprint("public", __name__)
+
+
+@public_bp.get("/")
+def home():
+    return render_template("index.html")

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -1,0 +1,127 @@
+:root{
+  --bg:#0b1220;
+  --panel:#121a2a;
+  --accent:#33b1ff;
+  --text:#e8eefb;
+  --muted:#9fb2d0;
+  --card:#141e31;
+  --card-hover:#1a2640;
+  --border:#223454;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+a{color:inherit;text-decoration:none}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+
+.navbar{
+  position:sticky;top:0;z-index:10;
+  display:flex;align-items:center;justify-content:space-between;
+  padding:12px 18px;border-bottom:1px solid var(--border);background:rgba(11,18,32,0.85);backdrop-filter:blur(6px)
+}
+.brand{font-weight:600;letter-spacing:.3px}
+.nav-right{display:flex;gap:10px}
+.btn{
+  padding:8px 14px;border-radius:10px;background:var(--accent);
+  color:#001726;font-weight:600;border:1px solid transparent;transition:.2s
+}
+.btn:hover{filter:brightness(1.05)}
+.btn.outline{
+  background:transparent;border-color:var(--border);color:var(--text)
+}
+.btn.outline:hover{background:var(--panel)}
+
+.container{max-width:1100px;margin:28px auto;padding:0 16px}
+.hero h1{margin:4px 0 4px;font-size:28px}
+.hero .muted{color:var(--muted);margin:6px 0 18px}
+
+.grid{
+  display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:14px;
+}
+@media(min-width:640px){.grid{grid-template-columns:repeat(2,1fr)}}
+@media(min-width:980px){.grid{grid-template-columns:repeat(3,1fr)}}
+
+.grid > a.card{
+  display:block;padding:16px;border:1px solid var(--border);border-radius:14px;
+  background:var(--card);transition:transform .15s ease, background .15s ease, border-color .15s ease
+}
+.grid > a.card:hover{transform:translateY(-2px);background:var(--card-hover);border-color:#2a4370}
+.grid > a.card h3{margin:0 0 6px 0;font-size:16px}
+.grid > a.card p{margin:0;color:var(--muted);font-size:14px;line-height:1.35}
+
+.helper .note{
+  margin-top:18px;padding:12px 14px;border:1px dashed var(--border);
+  border-radius:12px;background:var(--panel);color:var(--muted)
+}
+.about{margin-top:28px;display:flex;flex-direction:column;gap:10px}
+.external-link{
+  align-self:flex-start;padding:10px 16px;border-radius:12px;border:1px solid var(--border);
+  background:rgba(51,177,255,0.08);color:var(--accent);font-weight:600;transition:.2s
+}
+.external-link:hover{background:rgba(51,177,255,0.18);}
+.footer{
+  margin:28px auto 24px;max-width:1100px;padding:0 16px;color:var(--muted)
+}
+
+.flash-stack{display:flex;flex-direction:column;gap:10px;margin-bottom:20px}
+.flash{
+  padding:12px 14px;border-radius:12px;border:1px solid var(--border);
+  background:rgba(51,177,255,0.08);color:var(--text);font-size:14px
+}
+.flash.info{border-color:#3182ce}
+.flash.success{border-color:#2f855a;background:rgba(47,133,90,0.18)}
+.flash.warning{border-color:#b7791f;background:rgba(183,121,31,0.18)}
+.flash.danger{border-color:#c53030;background:rgba(197,48,48,0.18)}
+
+.admin-layout{
+  display:grid;
+  grid-template-columns:260px 1fr;
+  gap:24px;
+  margin-top:24px;
+}
+.admin-sidebar{
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:20px;
+}
+.admin-sidebar .brand{font-weight:600;margin-bottom:18px;display:block}
+.admin-sidebar nav{display:flex;flex-direction:column;gap:10px}
+.admin-sidebar nav a{
+  padding:10px 12px;border-radius:10px;color:var(--muted);
+  border:1px solid transparent;transition:.15s
+}
+.admin-sidebar nav a:hover{
+  color:var(--text);
+  border-color:var(--border);
+  background:rgba(51,177,255,0.08);
+}
+.admin-main{
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:24px;
+}
+.admin-main h1,.admin-main h2,.admin-main h3{color:var(--text);margin-top:0}
+.admin-main .card{
+  background:rgba(20,30,49,0.6);
+  border:1px solid var(--border);
+  border-radius:14px;
+  padding:12px;
+}
+.admin-main .card + .card{margin-top:12px}
+.admin-main .card-body{color:var(--muted)}
+.admin-main .table{width:100%;border-collapse:collapse;margin-top:16px;color:var(--muted)}
+.admin-main .table th,.admin-main .table td{border-bottom:1px solid var(--border);padding:10px 8px;text-align:left}
+.admin-main .badge{
+  display:inline-block;
+  border:1px solid var(--border);
+  border-radius:999px;
+  padding:4px 10px;
+  font-size:12px;
+  color:var(--muted);
+}
+
+@media(max-width:960px){
+  .admin-layout{grid-template-columns:1fr}
+  .admin-sidebar{position:relative}
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,130 +1,39 @@
 <!doctype html>
 <html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{% block title %}SGC{% endblock %}</title>
-
-    <!-- Bootstrap 5 -->
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous"
-    />
-
-    <!-- Custom (opcional) -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/sgc.css') }}">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/siglo21.png') }}">
-  </head>
-  <body class="d-flex flex-column min-vh-100">
-
-    <!-- NAVBAR -->
-    <nav class="navbar navbar-expand-lg navbar-light bg-white border-bottom shadow-sm">
-      <div class="container">
-        <a class="navbar-brand d-flex align-items-center"
-           href="{{ url_for('web.index') if has_web_index else url_for('auth.login') }}">
-          <img
-            src="{{ url_for('static', filename='img/siglo21.png') }}"
-            alt="Siglo 21"
-            class="me-2"
-            style="height: 36px; width: auto;"
-          />
-          <strong>SGC</strong>
-        </a>
-
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#topNav"
-                aria-controls="topNav" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div id="topNav" class="collapse navbar-collapse">
-          <ul class="navbar-nav ms-auto align-items-lg-center">
-            <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('web.index') if has_web_index else '#' }}">Inicio</a>
-            </li>
-            {% set simple_mode = config.get('AUTH_SIMPLE', True) %}
-            {% set simple_user = session.get('user') if simple_mode else None %}
-            {% if current_user.is_authenticated or simple_user %}
-              {% if current_user.is_authenticated %}
-                {% set active_role = current_user.role or ('admin' if current_user.is_admin else 'viewer') %}
-                {% set display_name = current_user.username %}
-                {% set display_title = current_user.title or active_role|capitalize %}
-              {% else %}
-                {% set active_role = simple_user.get('role') or ('admin' if simple_user.get('is_admin') else 'viewer') %}
-                {% set display_name = simple_user.get('username') %}
-                {% set display_title = simple_user.get('title') or active_role|capitalize %}
-              {% endif %}
-              {% set display_name = display_name or 'Usuario' %}
-              <li class="nav-item">
-                <span class="nav-link disabled text-muted">
-                  {{ display_name }} — {{ display_title }}
-                </span>
-              </li>
-              {% if active_role == 'admin' %}
-                <li class="nav-item">
-                  <a class="nav-link" href="{{ url_for('admin.index') }}">Panel Admin</a>
-                </li>
-              {% endif %}
-              {% if active_role in ['admin', 'supervisor', 'editor'] and has_web_upload %}
-                <li class="nav-item">
-                  <a class="nav-link" href="{{ url_for('web.upload') }}">Subir reporte</a>
-                </li>
-              {% endif %}
-              <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('auth.logout') }}">Salir</a>
-              </li>
-            {% else %}
-              <li class="nav-item">
-                <a class="nav-link" href="{{ url_for('auth.login') }}">Entrar</a>
-              </li>
-              {% if config.get('AUTH_SIMPLE', True) %}
-                <li class="nav-item">
-                  <a class="btn btn-sm btn-outline-secondary ms-lg-3 mt-3 mt-lg-0"
-                     href="{{ url_for('auth.register') }}">
-                    Crear usuario
-                  </a>
-                </li>
-              {% endif %}
-            {% endif %}
-          </ul>
-        </div>
-      </div>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>{% block title %}SGC — Obra de Dragado{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="navbar">
+    <div class="nav-left">
+      <span class="brand">SGC-Obra</span>
+    </div>
+    <nav class="nav-right">
+      <a class="btn" href="{{ url_for('auth.login') }}">Login</a>
+      <a class="btn outline" href="{{ url_for('admin.index') }}">Admin</a>
     </nav>
+  </header>
 
-    <!-- CONTENIDO -->
-    <main class="flex-grow-1">
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          <div class="container py-3">
-            {% for category, message in messages %}
-              <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                {{ message }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-              </div>
-            {% endfor %}
-          </div>
-        {% endif %}
-      {% endwith %}
-      {% block content %}{% endblock %}
-    </main>
-
-    <!-- FOOTER -->
-    <footer class="bg-light border-top py-4 mt-5">
-      <div class="container text-center text-muted small">
-        <div>© {{ 2025 }} SGC — Dragados y Urbanización Siglo 21</div>
-        <div class="mt-1">
-          <a class="text-decoration-none" href="{{ url_for('auth.login') }}">Acceso</a>
-          ·
-          <a class="text-decoration-none" href="{{ url_for('admin.index') }}">Admin</a>
+  <main class="container">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <div class="flash-stack">
+          {% for category, message in messages %}
+            <div class="flash {{ category }}">{{ message }}</div>
+          {% endfor %}
         </div>
-      </div>
-    </footer>
+      {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+  </main>
 
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-      crossorigin="anonymous"
-    ></script>
-  </body>
+  <footer class="footer">
+    <small>© {{ 2025 }} SGC — Control de Calidad y Seguridad en Obra de Dragado</small>
+  </footer>
+</body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block title %}Inicio — SGC{% endblock %}
+{% block content %}
+
+<section class="hero">
+  <h1>Control de Calidad — Obra de Dragado</h1>
+  <span class="sr-only">SGC - Sistema de Gestión de Calidad</span>
+  <p class="muted">
+    Accesos rápidos a las normas aplicables para el proyecto Huasteca Fuel Terminal.
+    Cada enlace abre en una nueva pestaña.
+  </p>
+</section>
+
+<section class="grid">
+  <!-- Ejemplos de NOM relevantes. Ajusta URLs oficiales que usas. -->
+  <a class="card" href="https://www.dof.gob.mx/" target="_blank" rel="noopener">
+    <h3>NOM-032-SEMARNAT</h3>
+    <p>Gestión ambiental en sitios de disposición. Impacto: manejo de materiales de dragado y disposición segura.</p>
+  </a>
+
+  <a class="card" href="https://www.dof.gob.mx/" target="_blank" rel="noopener">
+    <h3>NOM-083-SEMARNAT</h3>
+    <p>Residuos sólidos urbanos y de manejo especial. Impacto: clasificación, bitácoras y confinamiento temporal.</p>
+  </a>
+
+  <a class="card" href="https://www.stps.gob.mx/" target="_blank" rel="noopener">
+    <h3>NOM-017-STPS</h3>
+    <p>Equipos de Protección Personal (EPP). Impacto: listas de verificación y control de EPP en frente de obra.</p>
+  </a>
+
+  <a class="card" href="https://www.stps.gob.mx/" target="_blank" rel="noopener">
+    <h3>NOM-019-STPS</h3>
+    <p>Comisiones de seguridad e higiene. Impacto: actas, recorridos y reportes de condiciones inseguras.</p>
+  </a>
+
+  <a class="card" href="https://www.stps.gob.mx/" target="_blank" rel="noopener">
+    <h3>NOM-030-STPS</h3>
+    <p>Servicios preventivos de seguridad y salud. Impacto: registros, capacitación y seguimiento.</p>
+  </a>
+
+  <a class="card" href="https://www.gob.mx/profepa" target="_blank" rel="noopener">
+    <h3>Lineamientos PROFEPA</h3>
+    <p>Supervisión ambiental. Impacto: trazabilidad de residuos y cumplimiento en bordos y vertidos.</p>
+  </a>
+</section>
+
+<section class="helper">
+  <div class="note">
+    <strong>Nota:</strong> si necesitas volver a iniciar sesión, usa el botón <em>Login</em> en la barra superior.
+  </div>
+</section>
+
+<section class="about">
+  <p class="muted">SGC — Sistema de Gestión de Calidad para Huasteca Fuel Terminal.</p>
+  <a class="external-link" href="https://www.dusiglo21.com" target="_blank" rel="noopener">
+    Conoce más acerca de nosotros
+  </a>
+</section>
+
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace the shared base template with a lightweight navigation/header-footer layout and flash messaging hooks
- add a new public index template with NOM links, project context, and external reference plus matching dark theme styles
- register a dedicated public blueprint for `/` and move the authenticated web dashboard to `/dashboard`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceba09ef3083268679a769c148851e