### PR TITLE
Add public landing page and styling

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -79,6 +79,9 @@ def index():
     )
 
 
+bp_admin.add_url_rule("/", view_func=index, endpoint="dashboard")
+
+
 @bp_admin.get("/kpi/<int:project_id>.json")
 @login_required
 @admin_required

--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -1,127 +1,24 @@
-:root{
-  --bg:#0b1220;
-  --panel:#121a2a;
-  --accent:#33b1ff;
-  --text:#e8eefb;
-  --muted:#9fb2d0;
-  --card:#141e31;
-  --card-hover:#1a2640;
-  --border:#223454;
-}
-*{box-sizing:border-box}
-html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-a{color:inherit;text-decoration:none}
-.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+body { font-family: Arial, sans-serif; margin:0; background:#0b1220; color:#e8eefb; }
+a { text-decoration:none; }
+.sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 
-.navbar{
-  position:sticky;top:0;z-index:10;
-  display:flex;align-items:center;justify-content:space-between;
-  padding:12px 18px;border-bottom:1px solid var(--border);background:rgba(11,18,32,0.85);backdrop-filter:blur(6px)
-}
-.brand{font-weight:600;letter-spacing:.3px}
-.nav-right{display:flex;gap:10px}
-.btn{
-  padding:8px 14px;border-radius:10px;background:var(--accent);
-  color:#001726;font-weight:600;border:1px solid transparent;transition:.2s
-}
-.btn:hover{filter:brightness(1.05)}
-.btn.outline{
-  background:transparent;border-color:var(--border);color:var(--text)
-}
-.btn.outline:hover{background:var(--panel)}
+.navbar { display:flex; justify-content:space-between; padding:12px 18px; background:#121a2a; }
+.brand { font-weight:bold; }
+.btn { padding:8px 14px; border-radius:8px; background:#33b1ff; color:#001726; font-weight:600; }
+.btn.outline { background:transparent; border:1px solid #223454; color:#e8eefb; }
 
-.container{max-width:1100px;margin:28px auto;padding:0 16px}
-.hero h1{margin:4px 0 4px;font-size:28px}
-.hero .muted{color:var(--muted);margin:6px 0 18px}
+.container { max-width:1100px; margin:28px auto; padding:0 16px; }
+.hero h1 { font-size:28px; margin-bottom:4px; }
+.muted { color:#9fb2d0; }
 
-.grid{
-  display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:14px;
-}
-@media(min-width:640px){.grid{grid-template-columns:repeat(2,1fr)}}
-@media(min-width:980px){.grid{grid-template-columns:repeat(3,1fr)}}
+.grid { display:grid; gap:14px; grid-template-columns:repeat(auto-fit, minmax(250px,1fr)); }
+.card { background:#141e31; padding:16px; border-radius:10px; border:1px solid #223454; }
+.card:hover { background:#1a2640; }
+.card h3 { margin:0 0 6px; font-size:16px; }
+.card p { margin:0; color:#9fb2d0; font-size:14px; }
 
-.grid > a.card{
-  display:block;padding:16px;border:1px solid var(--border);border-radius:14px;
-  background:var(--card);transition:transform .15s ease, background .15s ease, border-color .15s ease
-}
-.grid > a.card:hover{transform:translateY(-2px);background:var(--card-hover);border-color:#2a4370}
-.grid > a.card h3{margin:0 0 6px 0;font-size:16px}
-.grid > a.card p{margin:0;color:var(--muted);font-size:14px;line-height:1.35}
+.about { margin-top:28px; }
+.external-link { display:inline-block; margin-top:10px; color:#33b1ff; font-weight:600; }
+.external-link:hover { text-decoration:underline; }
 
-.helper .note{
-  margin-top:18px;padding:12px 14px;border:1px dashed var(--border);
-  border-radius:12px;background:var(--panel);color:var(--muted)
-}
-.about{margin-top:28px;display:flex;flex-direction:column;gap:10px}
-.external-link{
-  align-self:flex-start;padding:10px 16px;border-radius:12px;border:1px solid var(--border);
-  background:rgba(51,177,255,0.08);color:var(--accent);font-weight:600;transition:.2s
-}
-.external-link:hover{background:rgba(51,177,255,0.18);}
-.footer{
-  margin:28px auto 24px;max-width:1100px;padding:0 16px;color:var(--muted)
-}
-
-.flash-stack{display:flex;flex-direction:column;gap:10px;margin-bottom:20px}
-.flash{
-  padding:12px 14px;border-radius:12px;border:1px solid var(--border);
-  background:rgba(51,177,255,0.08);color:var(--text);font-size:14px
-}
-.flash.info{border-color:#3182ce}
-.flash.success{border-color:#2f855a;background:rgba(47,133,90,0.18)}
-.flash.warning{border-color:#b7791f;background:rgba(183,121,31,0.18)}
-.flash.danger{border-color:#c53030;background:rgba(197,48,48,0.18)}
-
-.admin-layout{
-  display:grid;
-  grid-template-columns:260px 1fr;
-  gap:24px;
-  margin-top:24px;
-}
-.admin-sidebar{
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:16px;
-  padding:20px;
-}
-.admin-sidebar .brand{font-weight:600;margin-bottom:18px;display:block}
-.admin-sidebar nav{display:flex;flex-direction:column;gap:10px}
-.admin-sidebar nav a{
-  padding:10px 12px;border-radius:10px;color:var(--muted);
-  border:1px solid transparent;transition:.15s
-}
-.admin-sidebar nav a:hover{
-  color:var(--text);
-  border-color:var(--border);
-  background:rgba(51,177,255,0.08);
-}
-.admin-main{
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:16px;
-  padding:24px;
-}
-.admin-main h1,.admin-main h2,.admin-main h3{color:var(--text);margin-top:0}
-.admin-main .card{
-  background:rgba(20,30,49,0.6);
-  border:1px solid var(--border);
-  border-radius:14px;
-  padding:12px;
-}
-.admin-main .card + .card{margin-top:12px}
-.admin-main .card-body{color:var(--muted)}
-.admin-main .table{width:100%;border-collapse:collapse;margin-top:16px;color:var(--muted)}
-.admin-main .table th,.admin-main .table td{border-bottom:1px solid var(--border);padding:10px 8px;text-align:left}
-.admin-main .badge{
-  display:inline-block;
-  border:1px solid var(--border);
-  border-radius:999px;
-  padding:4px 10px;
-  font-size:12px;
-  color:var(--muted);
-}
-
-@media(max-width:960px){
-  .admin-layout{grid-template-columns:1fr}
-  .admin-sidebar{position:relative}
-}
+.footer { margin:28px auto; text-align:center; color:#9fb2d0; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,17 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>{% block title %}SGC — Obra de Dragado{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 </head>
 <body>
   <header class="navbar">
-    <div class="nav-left">
-      <span class="brand">SGC-Obra</span>
-    </div>
+    <div class="nav-left"><span class="brand">SGC-Obra</span></div>
     <nav class="nav-right">
       <a class="btn" href="{{ url_for('auth.login') }}">Login</a>
-      <a class="btn outline" href="{{ url_for('admin.index') }}">Admin</a>
+      <a class="btn outline" href="{{ url_for('admin.dashboard') }}">Admin</a>
     </nav>
   </header>
 
@@ -33,7 +29,7 @@
   </main>
 
   <footer class="footer">
-    <small>© {{ 2025 }} SGC — Control de Calidad y Seguridad en Obra de Dragado</small>
+    <small>© 2025 SGC — Control de Calidad y Seguridad en Obra de Dragado</small>
   </footer>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,56 +5,39 @@
 <section class="hero">
   <h1>Control de Calidad — Obra de Dragado</h1>
   <span class="sr-only">SGC - Sistema de Gestión de Calidad</span>
-  <p class="muted">
-    Accesos rápidos a las normas aplicables para el proyecto Huasteca Fuel Terminal.
-    Cada enlace abre en una nueva pestaña.
-  </p>
+  <p class="muted">Accesos rápidos a las normas aplicables para el proyecto Huasteca Fuel Terminal.</p>
 </section>
 
 <section class="grid">
-  <!-- Ejemplos de NOM relevantes. Ajusta URLs oficiales que usas. -->
-  <a class="card" href="https://www.dof.gob.mx/" target="_blank" rel="noopener">
-    <h3>NOM-032-SEMARNAT</h3>
-    <p>Gestión ambiental en sitios de disposición. Impacto: manejo de materiales de dragado y disposición segura.</p>
+  <a class="card" href="https://www.dof.gob.mx/nota_detalle.php?codigo=4963405&fecha=20/10/2004#gsc.tab=0" target="_blank" rel="noopener">
+    <h3>NOM-083-SEMARNAT-2003</h3>
+    <p>Disposición final de residuos. Impacto: manejo del material dragado en sitios autorizados.</p>
   </a>
 
-  <a class="card" href="https://www.dof.gob.mx/" target="_blank" rel="noopener">
-    <h3>NOM-083-SEMARNAT</h3>
-    <p>Residuos sólidos urbanos y de manejo especial. Impacto: clasificación, bitácoras y confinamiento temporal.</p>
+  <a class="card" href="https://www.dof.gob.mx/nota_detalle.php?codigo=5072882&fecha=22/09/2008#gsc.tab=0" target="_blank" rel="noopener">
+    <h3>NOM-032-STPS-2008</h3>
+    <p>Seguridad en maquinaria y equipo. Impacto: uso seguro de dragas y excavadoras.</p>
   </a>
 
   <a class="card" href="https://www.stps.gob.mx/" target="_blank" rel="noopener">
     <h3>NOM-017-STPS</h3>
-    <p>Equipos de Protección Personal (EPP). Impacto: listas de verificación y control de EPP en frente de obra.</p>
+    <p>Equipos de Protección Personal. Impacto: control de EPP en frente de obra.</p>
   </a>
 
   <a class="card" href="https://www.stps.gob.mx/" target="_blank" rel="noopener">
     <h3>NOM-019-STPS</h3>
-    <p>Comisiones de seguridad e higiene. Impacto: actas, recorridos y reportes de condiciones inseguras.</p>
+    <p>Comisiones de seguridad e higiene. Impacto: actas y recorridos en campo.</p>
   </a>
 
   <a class="card" href="https://www.stps.gob.mx/" target="_blank" rel="noopener">
     <h3>NOM-030-STPS</h3>
-    <p>Servicios preventivos de seguridad y salud. Impacto: registros, capacitación y seguimiento.</p>
+    <p>Servicios preventivos de seguridad y salud. Impacto: capacitación y seguimiento.</p>
   </a>
-
-  <a class="card" href="https://www.gob.mx/profepa" target="_blank" rel="noopener">
-    <h3>Lineamientos PROFEPA</h3>
-    <p>Supervisión ambiental. Impacto: trazabilidad de residuos y cumplimiento en bordos y vertidos.</p>
-  </a>
-</section>
-
-<section class="helper">
-  <div class="note">
-    <strong>Nota:</strong> si necesitas volver a iniciar sesión, usa el botón <em>Login</em> en la barra superior.
-  </div>
 </section>
 
 <section class="about">
   <p class="muted">SGC — Sistema de Gestión de Calidad para Huasteca Fuel Terminal.</p>
-  <a class="external-link" href="https://www.dusiglo21.com" target="_blank" rel="noopener">
-    Conoce más acerca de nosotros
-  </a>
+  <a class="external-link" href="https://www.dusiglo21.com" target="_blank" rel="noopener">Conoce más acerca de nosotros</a>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- add public blueprint home view serving the refreshed landing page
- simplify the base layout with navigation to login and admin dashboard
- update index template and custom stylesheet with the provided public design
- expose the admin dashboard endpoint alias for navigation compatibility

## Testing
- `pytest tests/web/test_home.py`


------
https://chatgpt.com/codex/tasks/task_e_68cebc4ec3f883269fa0f8c34c508c80