### PR TITLE
feat(scanner): lock automático (PG advisory vs file lock)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,7 +24,7 @@ from .routes.public import public_bp
 from .config import get_config
 from .db import db
 from .extensions import csrf, init_auth_extensions, limiter
-from .utils.lock import file_lock
+from .utils.scan_lock import get_scan_lock
 from .cli import register_cli
 from .migrate_ext import init_migrations
 from .security_headers import set_security_headers
@@ -162,15 +162,12 @@ def create_app(config_name: str | None = None) -> Flask:
 
         def job() -> None:
             with app.app_context():
-                lock_path = os.getenv("SCAN_LOCK_FILE", "/tmp/sgc_scan.lock")
                 try:
-                    with file_lock(lock_path, timeout=3):
+                    with get_scan_lock():
                         stats = scan_all_folders()
                         app.logger.info("[scanner] %s", stats)
                 except TimeoutError:
-                    app.logger.info(
-                        "[scanner] saltado: otro proceso tiene el lock."
-                    )
+                    app.logger.info("[scanner] saltado: lock ocupado.")
 
         scheduler.add_job(
             job,

--- a/app/cli_sync.py
+++ b/app/cli_sync.py
@@ -9,7 +9,7 @@ from app.models.asset import Asset
 from app.models.folder import Folder
 from app.models import Project
 from app.services.scanner import scan_all_folders, scan_folder_record
-from app.utils.lock import file_lock
+from app.utils.scan_lock import get_scan_lock
 
 
 def register_sync_cli(app):
@@ -94,10 +94,11 @@ def register_sync_cli(app):
     def scan_all(limit: int | None) -> None:
         """Escanea todas las carpetas registradas."""
 
-        lock_path = os.getenv("SCAN_LOCK_FILE", "/tmp/sgc_scan.lock")
         try:
-            with file_lock(lock_path, timeout=3):
+            with get_scan_lock():
                 stats = scan_all_folders(limit=limit)
                 click.echo(f"✅ {stats}")
         except TimeoutError:
-            click.echo("⏭️  Saltado: ya hay un escaneo en curso.", err=True)
+            click.echo(
+                "⏭️  Saltado: lock ocupado (ya hay un escaneo en curso).", err=True
+            )

--- a/app/utils/scan_lock.py
+++ b/app/utils/scan_lock.py
@@ -1,0 +1,55 @@
+"""Helpers for obtaining the scanner lock across different backends."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.db import db
+
+from .lock import file_lock
+
+
+def _is_postgres(engine: Engine) -> bool:
+    """Return True when the SQLAlchemy engine is backed by PostgreSQL."""
+
+    try:
+        return (engine.dialect.name or "").startswith("postgres")
+    except Exception:  # pragma: no cover - extremely defensive
+        return False
+
+
+@contextmanager
+def advisory_lock_pg(key: int = 821_734):
+    """Acquire a PostgreSQL advisory lock for the given key."""
+
+    conn = db.engine.connect()
+    try:
+        got = conn.execute(text("SELECT pg_try_advisory_lock(:k)"), {"k": key}).scalar()
+        if not got:
+            raise TimeoutError("No pude obtener pg_advisory_lock")
+        yield
+    finally:
+        try:
+            conn.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
+        finally:
+            conn.close()
+
+
+@contextmanager
+def get_scan_lock():
+    """Return a context manager that provides the shared scanner lock."""
+
+    timeout = int(os.getenv("SCAN_LOCK_TIMEOUT", "3"))
+    key = int(os.getenv("SCAN_LOCK_KEY", "821734"))
+    lock_file = os.getenv("SCAN_LOCK_FILE", "/tmp/sgc_scan.lock")
+
+    if _is_postgres(db.engine):
+        with advisory_lock_pg(key=key):
+            yield
+    else:
+        with file_lock(lock_file, timeout=timeout):
+            yield


### PR DESCRIPTION
## Summary
- add a scan lock helper that chooses PostgreSQL advisory locks when available and falls back to file locks
- update the scheduler job and scan-all CLI command to share the new helper and unify logging/messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cef431335483268ac2d934fba424ae