### PR TITLE
fix: add prometheus metrics dependency and lazy load endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ psycopg2-binary==2.9.9
 # Scheduler y zonas horarias
 APScheduler>=3.10.4
 pytz>=2024.1
+
+# Metrics
+prometheus-client>=0.20.0


### PR DESCRIPTION
## Summary
- add prometheus-client to requirements so the metrics endpoint has its dependency in CI
- lazily import prometheus_client in the /metrics handler and return a fallback response when unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf03a2a2608326aae40898e1659478