### PR TITLE
Align database configuration with Render deployment requirements

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -11,19 +11,13 @@ from alembic import context
 from flask import current_app
 from sqlalchemy import engine_from_config, pool
 
-# Asegúrate de que el paquete principal esté disponible al ejecutar Alembic
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
-
-# Configuración de logging de Alembic (opcional)
+# Configuración del archivo de Alembic
 config = context.config
 
 db_url = os.getenv("DATABASE_URL", "")
 if db_url.startswith("postgres://"):
     db_url = db_url.replace("postgres://", "postgresql://", 1)
 if db_url:
-    # Forzar ssl en Render si no se indicó
     if (
         "sslmode=" not in db_url
         and "localhost" not in db_url
@@ -32,6 +26,11 @@ if db_url:
         sep = "&" if "?" in db_url else "?"
         db_url = f"{db_url}{sep}sslmode=require"
     config.set_main_option("sqlalchemy.url", db_url)
+
+# Asegúrate de que el paquete principal esté disponible al ejecutar Alembic
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/render.yaml
+++ b/render.yaml
@@ -19,6 +19,7 @@ services:
       pip install --upgrade pip
       pip install -r requirements.txt
     preDeployCommand: |
-      alembic upgrade head
-    startCommand: gunicorn -w 3 -t 60 app.main:app
+      alembic -c migrations/alembic.ini upgrade head && \
+      FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
+    startCommand: gunicorn -w 3 app.main:app
     healthCheckPath: /healthz


### PR DESCRIPTION
## Summary
- ensure Alembic picks up DATABASE_URL, normalises postgres:// URIs and enforces sslmode=require for non-local deployments
- resolve the SQLAlchemy database URI from the environment in `app.config`, keep pool pre-ping enabled and guard against production sqlite fallbacks
- update Render pre-deploy to run Alembic via the repo config and seed the default admin before launching gunicorn

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf55407468832692f6361fbf349a3f