### PR TITLE
Ensure Alembic uses app database URL

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,7 +21,7 @@ from .blueprints.web import bp_web
 from .cli_sync import register_sync_cli
 from .routes.assets import assets_bp
 from .routes.public import public_bp
-from .config import SQLALCHEMY_DATABASE_URI, get_config
+from .config import get_config
 from .db import db
 from .extensions import csrf, init_auth_extensions, limiter
 from .metrics import cleanup_multiprocess_directory
@@ -80,7 +80,12 @@ def create_app(config_name: str | None = None) -> Flask:
     # Asegura DATA_DIR y muestra la URI (útil en logs de Render)
     data_dir = Path(app.config["DATA_DIR"])
     data_dir.mkdir(parents=True, exist_ok=True)
-    app.logger.info(f"DB URI -> {SQLALCHEMY_DATABASE_URI}")
+
+    db_uri = str(app.config.get("SQLALCHEMY_DATABASE_URI", ""))
+    app.logger.info("DB URI -> %s", db_uri)
+    if db_uri.startswith("sqlite:///") and not db_uri.endswith(":memory:"):
+        sqlite_path = Path(db_uri.replace("sqlite:///", "", 1)).expanduser().resolve()
+        app.logger.info("[DEBUG] SQLite file -> %s", sqlite_path)
 
     # Directorios persistentes (DATA_DIR, instance/, etc.)
     ensure_dirs(app)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,72 +1,30 @@
-import os
 from logging.config import fileConfig
+from pathlib import Path
+import sys
+
 from sqlalchemy import engine_from_config, pool
 from alembic import context
+
 
 config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 
-def _normalize(url: str) -> str:
-    if url.startswith("postgres://"):
-        url = url.replace("postgres://", "postgresql://", 1)
-    if url and ("sslmode=" not in url) and ("localhost" not in url) and ("127.0.0.1" not in url):
-        sep = "&" if "?" in url else "?"
-        url = f"{url}{sep}sslmode=require"
-    return url
-
-
-def _resolve_db_url() -> str:
-    # 1) Environment
-    env_url = os.getenv("DATABASE_URL", "").strip()
-    if env_url:
-        return _normalize(env_url)
-    # 2) App config (si existe)
-    try:
-        from app.config import resolve_db_uri
-
-        app_url = resolve_db_uri()
-        if app_url:
-            return _normalize(app_url)
-    except Exception:
-        pass
-    # 3) alembic.ini (último recurso)
-    ini_url = (config.get_main_option("sqlalchemy.url", "") or "").strip()
-    if ini_url:
-        return _normalize(ini_url)
-    raise RuntimeError("No DB URL: define DATABASE_URL o sqlalchemy.url en alembic.ini")
-
-
-db_url = _resolve_db_url()
-config.set_main_option("sqlalchemy.url", db_url)  # *** CRÍTICO: antes de engine_from_config ***
-
-import atexit
-import sys
-from contextlib import ExitStack, nullcontext
-from pathlib import Path
-
-from flask import current_app
-
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-stack = ExitStack()
-atexit.register(stack.close)
+from app import create_app, db as _db
 
-try:
-    app = current_app._get_current_object()
-    ctx = nullcontext()
-except RuntimeError:
-    from app import create_app
+app = create_app()
+db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
+if not db_uri:
+    raise RuntimeError("SQLALCHEMY_DATABASE_URI no está configurado en la app")
 
-    app = create_app()
-    ctx = app.app_context()
+config.set_main_option("sqlalchemy.url", db_uri)
 
-stack.enter_context(ctx)
-
-target_metadata = app.extensions["migrate"].db.metadata
+target_metadata = _db.metadata
 
 
 def run_migrations_offline():


### PR DESCRIPTION
## Summary
- load the Flask application inside Alembic so migrations reuse the app-configured database URL
- log the effective database URI at startup and show the resolved SQLite file path for easier debugging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0cb52aad08326b97619d2da0edc4f