### PR TITLE
Configure Alembic and deployment tooling for Render

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,20 +1,73 @@
+# manage.py
 import click
-from flask_migrate import upgrade
-from app.main import app  # importa tu app ya inicializada con Migrate
+from alembic import command
+from alembic.config import Config
+from flask.cli import with_appcontext
+
+from app import create_app
+
+app = create_app()
 
 
-@click.group()
-def cli():
-    pass
+def _alembic_cfg() -> Config:
+    cfg = Config("migrations/alembic.ini")
+    # Alembic tomará la URL desde env.py (inyectada por la app)
+    return cfg
 
 
-@cli.command("db-upgrade")
+@app.cli.command("db-upgrade")
+@with_appcontext
 def db_upgrade():
-    """Aplica las migraciones de Alembic."""
-    with app.app_context():
-        upgrade()
-        click.echo("DB upgraded successfully")
+    """Aplica las migraciones hasta head."""
+    command.upgrade(_alembic_cfg(), "head")
+    click.echo("✅ Alembic upgrade head OK")
+
+
+@app.cli.command("db-downgrade")
+@click.argument("rev", default="-1")
+@with_appcontext
+def db_downgrade(rev):
+    """Revierte una migración. Por defecto: -1 (una atrás)."""
+    command.downgrade(_alembic_cfg(), rev)
+    click.echo(f"✅ Alembic downgrade {rev} OK")
+
+
+@app.cli.command("seed-admin")
+@click.option("--email", required=True)
+@click.option("--password", required=True)
+@with_appcontext
+def seed_admin(email, password):
+    """
+    Crea/asegura usuario admin. Si ya tienes un 'flask seed-admin' nativo en app/cli.py,
+    puedes borrar este o mantenerlo; no hay conflicto si el endpoint tiene otro nombre.
+    """
+    try:
+        from app.models import User  # ajusta el import a tu estructura real
+        from app import db
+
+        email_n = email.strip().lower()
+        user = User.query.filter_by(email=email_n).first()
+        if user:
+            click.echo("ℹ️ Admin ya existe; no se cambia la contraseña.")
+            return
+
+        user = User(
+            email=email_n,
+            username="admin",
+            is_admin=True,
+            is_active=True,
+            role="admin",
+            title="Administrator",
+        )
+        user.set_password(password)  # asegúrate que tu modelo tenga este método
+        db.session.add(user)
+        db.session.commit()
+        click.echo("✅ Admin creado.")
+    except Exception as e:
+        click.echo(f"❌ Error seeding admin: {e}")
+        raise
 
 
 if __name__ == "__main__":
-    cli()
+    # Uso directo (equivalente a 'flask run'); en Render usamos gunicorn
+    app.run(host="0.0.0.0", port=5000)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,70 +1,55 @@
 from __future__ import annotations
 
 from logging.config import fileConfig
-
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-
-# === Carga la app para tomar la DB URL y el metadata ===
-# Soportamos dos ubicaciones comunes de 'db'
 def _load_app_and_db():
     from app import create_app
-
     app = create_app()
 
-    # Intenta importar db desde app.extensions, si no, desde app
+    # Intenta obtener 'db' desde app.extensions o app
     db = None
     try:
-        from app.extensions import db as _db  # Flask-SQLAlchemy
-
+        from app.extensions import db as _db
         db = _db
     except Exception:
         try:
             from app import db as _db2
-
             db = _db2
         except Exception as e:
             raise RuntimeError(
-                "No pude importar 'db'. Asegúrate de exponer 'db' en app.extensions o app.__init__"
+                "No pude importar 'db'. Expón 'db' en app.extensions o en app.__init__"
             ) from e
-
     return app, db
-
 
 app, db = _load_app_and_db()
 db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
 if not db_uri:
     raise RuntimeError("SQLALCHEMY_DATABASE_URI no está definido en la app.")
 
-# Alembic config
 config = context.config
 if config.config_file_name:
     fileConfig(config.config_file_name)
 
-# Fuerza a Alembic a usar la misma URL que la app
+# Fuerza a Alembic a usar la misma URL que usa la app
 config.set_main_option("sqlalchemy.url", db_uri)
 
-# Metadata objetivo para autogenerate
 target_metadata = getattr(db, "metadata", None) or getattr(db, "Model", None).metadata
 
-
 def run_migrations_offline() -> None:
-    """Modo offline: usa URL literal"""
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
         target_metadata=target_metadata,
-        compare_type=True,  # detecta cambios de tipos
-        render_as_batch=True,  # seguro para ALTER TABLE en SQLite
+        compare_type=True,
+        render_as_batch=False,  # En Postgres no hace falta batch mode
         literal_binds=True,
     )
     with context.begin_transaction():
         context.run_migrations()
 
-
 def run_migrations_online() -> None:
-    """Modo online: usa engine/connection"""
     connectable = engine_from_config(
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
@@ -75,11 +60,10 @@ def run_migrations_online() -> None:
             connection=connection,
             target_metadata=target_metadata,
             compare_type=True,
-            render_as_batch=True,  # importante para SQLite
+            render_as_batch=False,
         )
         with context.begin_transaction():
             context.run_migrations()
-
 
 if context.is_offline_mode():
     run_migrations_offline()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,15 +17,15 @@ email-validator>=2.2.0
 # Testing
 pytest==8.3.3
 pytest-cov==5.0.0
-Flask-SQLAlchemy==3.1.1
-SQLAlchemy==2.0.32
+Flask-SQLAlchemy>=3.1.1
+SQLAlchemy>=2.0.32
 
 # Migraciones
 Flask-Migrate==4.0.7
-alembic==1.13.2
+alembic>=1.13.2
 
 # Drivers de base de datos
-psycopg2-binary>=2.9.9
+psycopg[binary]>=3.2.1
 
 # Scheduler y zonas horarias
 APScheduler>=3.10.4

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,8 @@
+# wsgi.py
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    # Útil para pruebas locales; en Render se usa gunicorn
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- switch the project requirements to psycopg v3 and ensure Alembic/SQLAlchemy minimums for Render
- configure Alembic to load the Flask application for its database URL and metadata
- add a standard wsgi entrypoint and enhanced manage.py CLI commands for migrations and seeding

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0d474bcdc8326bcb85ebbe065defe