### PR TITLE
feat(db): unify Postgres URL for app & alembic; add wsgi/manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,20 +1,29 @@
+# manage.py
 import click
-from flask_migrate import upgrade
-from app.main import app  # importa tu app ya inicializada con Migrate
+from alembic import command
+from alembic.config import Config
+from flask.cli import with_appcontext
+
+from app import create_app
+
+app = create_app()
 
 
-@click.group()
-def cli():
-    pass
+def _alembic_cfg() -> Config:
+    cfg = Config("migrations/alembic.ini")
+    return cfg
 
 
-@cli.command("db-upgrade")
+@app.cli.command("db-upgrade")
+@with_appcontext
 def db_upgrade():
-    """Aplica las migraciones de Alembic."""
-    with app.app_context():
-        upgrade()
-        click.echo("DB upgraded successfully")
+    command.upgrade(_alembic_cfg(), "head")
+    click.echo("✅ Alembic upgrade head OK")
 
 
-if __name__ == "__main__":
-    cli()
+@app.cli.command("db-downgrade")
+@click.argument("rev", default="-1")
+@with_appcontext
+def db_downgrade(rev):
+    command.downgrade(_alembic_cfg(), rev)
+    click.echo(f"✅ Alembic downgrade {rev} OK")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,15 +17,15 @@ email-validator>=2.2.0
 # Testing
 pytest==8.3.3
 pytest-cov==5.0.0
-Flask-SQLAlchemy==3.1.1
-SQLAlchemy==2.0.32
+Flask-SQLAlchemy>=3.1.1
+SQLAlchemy>=2.0.30
 
 # Migraciones
 Flask-Migrate==4.0.7
-alembic==1.13.2
+alembic>=1.13.2
 
 # Drivers de base de datos
-psycopg2-binary>=2.9.9
+psycopg[binary]>=3.2.1
 
 # Scheduler y zonas horarias
 APScheduler>=3.10.4

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,7 @@
+# wsgi.py
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- ensure Alembic shares the same database URL as the Flask factory by loading it from the application
- add production entry points via wsgi.py and manage.py helpers for Alembic upgrades and downgrades
- update ORM-related requirements for Postgres deployments, including psycopg binary wheels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0d9061afc83269df555be63a20519