### PR TITLE
Use dedicated WSGI entrypoint for Gunicorn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 # Proceso web principal (sirve la app Flask con Gunicorn)
-web: gunicorn -w 3 -t 60 app.main:app
+web: gunicorn -w 3 -t 60 wsgi:app
 
 # Proceso de worker (ejemplo: tareas en segundo plano)
 worker: python worker.py

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ En producción la aplicación fuerza cookies `Secure`, `HttpOnly` y `SameSite=La
 
 ## Operación
 
-- **Gunicorn:** El Procfile y `render.yaml` inician el proyecto con `gunicorn -w 3 -t 60 app.main:app`.
+- **Gunicorn:** El Procfile y `render.yaml` inician el proyecto con `gunicorn -w 3 -t 60 wsgi:app`.
 - **Healthcheck:** `GET /healthz` devuelve `{"ok": true}` para liveness probes; `/api/v1/health` valida la conexión a la base.
 - **Logging estructurado:** todos los logs van a `stdout` en JSON-like plano, incluyen `X-Request-ID` y respetan `LOG_LEVEL`.
 - **Rate limiting:** `/auth/forgot-password` limita solicitudes a `5/minuto` y `30/hora` por IP.
@@ -49,7 +49,7 @@ El archivo `Procfile` describe los procesos que tu plataforma de despliegue debe
 
 ```Procfile
 # Proceso web principal (sirve la app Flask con Gunicorn)
-web: gunicorn -w 3 -t 60 app.main:app
+web: gunicorn -w 3 -t 60 wsgi:app
 
 # Proceso de worker (ejemplo: tareas en segundo plano)
 worker: python worker.py
@@ -60,7 +60,7 @@ worker: python worker.py
 - Atiende el tráfico HTTP usando Gunicorn.
 - `-w 3` levanta tres workers; ajusta el número según el plan contratado o los núcleos disponibles.
 - `-t 60` fija un timeout de 60 s para peticiones largas.
-- `app.main:app` apunta al objeto Flask creado en `app/main.py`.
+- `wsgi:app` apunta al objeto Flask creado en `wsgi.py`.
 
 Render reutiliza este comando como *Start Command*; basta con mantener el `Procfile` en el repositorio para que lo detecte automáticamente.
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,9 @@
-"""Punto de entrada para servidores WSGI como gunicorn."""
+"""Punto de entrada WSGI conservado por compatibilidad."""
 
 from __future__ import annotations
 
 from . import create_app
 
-# Render arranca con: ``gunicorn app.main:app --bind 0.0.0.0:$PORT``
+# Usa ``gunicorn wsgi:app`` en producción; este módulo queda disponible
+# para procesos auxiliares o tooling que aún dependan de ``app.main:app``.
 app = create_app()

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,6 @@
 import click
 from flask_migrate import upgrade
-from app.main import app  # importa tu app ya inicializada con Migrate
+from wsgi import app  # importa tu app ya inicializada con Migrate
 
 
 @click.group()

--- a/render.yaml
+++ b/render.yaml
@@ -21,5 +21,5 @@ services:
     preDeployCommand: |
       alembic -c migrations/alembic.ini upgrade head && \
       FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
-    startCommand: gunicorn -w 3 app.main:app
+    startCommand: gunicorn -w 3 wsgi:app
     healthCheckPath: /healthz

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,9 @@
+"""Punto de entrada WSGI para Gunicorn y servidores similares."""
+
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- add a root-level `wsgi.py` module that instantiates the Flask app
- switch Render, Procfile and documentation to point Gunicorn at `wsgi:app`
- keep `app.main` as a compatibility wrapper and update management script import

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d10d6d4c5c832695d6d02604a2f2e2