### PR TITLE
chore(seed): remove ADMIN_PASSWORD dep; default admin password to admin123

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Configura las variables de entorno **antes** de desplegar en Render u otra plata
 
 En producción la aplicación fuerza cookies `Secure`, `HttpOnly` y `SameSite=Lax`, protege los formularios con CSRF y aplica cabeceras de seguridad (CSP, HSTS, etc.).
 
+> ℹ️ El seeding por defecto crea `admin@admin.com` / `admin123`.
+
+Para usar otra clave, ejecutar:
+
+```bash
+FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password NUEVA_CLAVE
+```
+
 ## Operación
 
 - **Gunicorn:** El Procfile y `render.yaml` inician el proyecto con `gunicorn -w 3 -t 60 wsgi:app`.

--- a/app/config.py
+++ b/app/config.py
@@ -59,7 +59,6 @@ class BaseConfig:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ENGINE_OPTIONS = dict(SQLALCHEMY_ENGINE_OPTIONS)
     RATELIMIT_STORAGE_URI = _RATELIMIT_STORAGE_URI
-    ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "admin")
     AUTH_SIMPLE = os.getenv("AUTH_SIMPLE", "0").lower() in ("1", "true", "yes")
     SESSION_COOKIE_HTTPONLY = True
     _secure_cookies_flag = os.getenv("SECURE_COOKIES")

--- a/app/scripts/create_admin.py
+++ b/app/scripts/create_admin.py
@@ -9,6 +9,7 @@ from werkzeug.security import generate_password_hash
 from app import create_app
 from app.db import db
 from app.models import User
+from app.utils.strings import normalize_email
 
 
 def main() -> None:
@@ -17,27 +18,52 @@ def main() -> None:
     app = create_app(os.getenv("CONFIG", "development"))
     username = os.getenv("ADMIN_USERNAME", "admin")
     email = os.getenv("ADMIN_EMAIL", "admin@example.com")
-    password = os.getenv("ADMIN_PASSWORD", "admin123")
+    password = "admin123"
 
     with app.app_context():
-        user = User.query.filter_by(username=username).first()
+        email_n = normalize_email(email)
+        if not email_n:
+            print("❌ Email inválido; no se crea el admin.")
+            return
+
+        user = User.query.filter_by(email=email_n).first()
         if user:
-            print("ℹ️ El usuario admin ya existe")
+            print("ℹ️ El usuario admin ya existe; no se cambia la contraseña.")
+            return
+
+        resolved_username = (username or email_n.split("@", 1)[0] or "admin").strip()
+        if User.query.filter_by(username=resolved_username).first():
+            print(
+                "ℹ️ Ya existe un usuario con ese username; ajusta ADMIN_USERNAME y reintenta."
+            )
             return
 
         user = User(
-            username=username,
-            email=email,
+            username=resolved_username,
+            email=email_n,
             role="admin",
             is_admin=True,
             is_active=True,
         )
-        user.password_hash = generate_password_hash(password)
+        if hasattr(user, "set_password"):
+            user.set_password(password)
+        elif hasattr(user, "password_hash"):
+            user.password_hash = generate_password_hash(password)
+        else:
+            print(
+                "❌ El modelo de usuario no soporta asignar contraseña de forma automática."
+            )
+            return
+
+        try:
+            user.force_change_password = True
+        except Exception:
+            pass
         db.session.add(user)
         db.session.commit()
         print(
-            f"✅ Usuario admin creado -> {username} / {password}"
-            f" (email: {email})"
+            f"✅ Usuario admin creado -> {resolved_username} / {password}"
+            f" (email: {email_n})"
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ if str(PROJECT_ROOT) not in sys.path:
 def app(monkeypatch, tmp_path):
     """Instancia de la aplicación configurada para pruebas con DB temporal."""
 
-    monkeypatch.setenv("ADMIN_PASSWORD", "pass123")
     monkeypatch.setenv("SECRET_KEY", "tests-secret")
     monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
 


### PR DESCRIPTION
## Summary
- default the CLI seed-admin command to create admin accounts with admin123 when no password is provided
- update the local create_admin helper to use the same default behavior and skip resetting existing admins
- remove the ADMIN_PASSWORD configuration/env usage and document the default credentials

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1149d1cfc832696b36ea1d646601a