### PR TITLE
fix(deploy): install psycopg v3 and drop psycopg2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Configura las variables de entorno **antes** de desplegar en Render u otra plata
 | `SECURE_COOKIES` | `1` para forzar cookies seguras en HTTPS. |
 | `LOG_LEVEL` | `INFO` (o `DEBUG` solo para diagnósticos puntuales). |
 
+> Nota: la aplicación usa `postgresql+psycopg://` (psycopg v3). No instales `psycopg2` ni `psycopg2-binary`; mantenemos `psycopg[binary]` en `requirements.txt`.
+
 En producción la aplicación fuerza cookies `Secure`, `HttpOnly` y `SameSite=Lax`, protege los formularios con CSRF y aplica cabeceras de seguridad (CSP, HSTS, etc.).
 
 ## Operación

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,15 +17,15 @@ email-validator>=2.2.0
 # Testing
 pytest==8.3.3
 pytest-cov==5.0.0
-Flask-SQLAlchemy==3.1.1
-SQLAlchemy==2.0.32
+Flask-SQLAlchemy>=3.1.1
+SQLAlchemy>=2.0.30
 
 # Migraciones
 Flask-Migrate==4.0.7
-alembic==1.13.2
+alembic>=1.13.2
 
 # Drivers de base de datos
-psycopg2-binary>=2.9.9
+psycopg[binary]>=3.2,<4
 
 # Scheduler y zonas horarias
 APScheduler>=3.10.4


### PR DESCRIPTION
## Summary
- replace psycopg2-binary with psycopg[binary] v3 and bump SQLAlchemy-related constraints to required minimums
- document in the README that deployments must keep psycopg[binary] instead of psycopg2

## Testing
- python -m pip install --upgrade pip
- python -m pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68d117b1d0d88326b2f7572da519d296