### PR TITLE
fix(migrations): use boolean server_default false/true for PostgreSQL compatibility

### DIFF
--- a/migrations/versions/20250917_create_folders.py
+++ b/migrations/versions/20250917_create_folders.py
@@ -18,8 +18,8 @@ def upgrade():
         sa.Column("parent_id", sa.Integer(), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),
-        # En SQLite, booleans usan 0/1 como texto; evita 'false' literal
-        sa.Column("is_root", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        # En SQLite y PostgreSQL, expresamos el default como literal booleano
+        sa.Column("is_root", sa.Boolean(), nullable=False, server_default=sa.text("false")),
         sa.ForeignKeyConstraint(["parent_id"], ["folders.id"], ondelete="CASCADE"),
         sa.UniqueConstraint("parent_id", "slug", name="uq_folders_parent_slug"),
     )

--- a/migrations/versions/d736c9cafb61_initial_tables.py
+++ b/migrations/versions/d736c9cafb61_initial_tables.py
@@ -191,7 +191,7 @@ def upgrade():
             "done",
             sa.Boolean(),
             nullable=False,
-            server_default=sa.text("0"),
+            server_default=sa.text("false"),
         ),
     )
 
@@ -203,7 +203,7 @@ def upgrade():
             "completed",
             sa.Boolean(),
             nullable=False,
-            server_default=sa.text("0"),
+            server_default=sa.text("false"),
         ),
         sa.Column(
             "created_at",


### PR DESCRIPTION
## Summary
- update legacy migrations to use boolean literals for `server_default` values
- ensure folder and checklist item defaults align with PostgreSQL expectations

## Testing
- `alembic -c migrations/alembic.ini upgrade head`


------
https://chatgpt.com/codex/tasks/task_e_68d11a122b1083268494868a4c171ea4