### PR TITLE
fix(migrations): shorten revision ids to <=32 and update down_revision

### DIFF
--- a/migrations/versions/20250916_add_force_change_password.py
+++ b/migrations/versions/20250916_add_force_change_password.py
@@ -3,7 +3,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # OJO: deja estos IDs como los tienes en tu repo
-revision = "20250916_add_force_change_password"
+revision = "20250916_force_change_pw"
 down_revision = "20240201_create_users"
 branch_labels = None
 depends_on = None

--- a/migrations/versions/20250917_usernames.py
+++ b/migrations/versions/20250917_usernames.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 
 # OJO: actualiza esto si tu down_revision real es otro
 revision = "20250917_usernames"
-down_revision = "20250916_add_force_change_password"
+down_revision = "20250916_force_change_pw"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- shorten the long `20250916_add_force_change_password` revision id to `20250916_force_change_pw`
- update dependent `down_revision` in the usernames migration to reference the new id
- verify no other revisions exceed 32 characters and keep the chain intact

## Testing
- alembic -c migrations/alembic.ini history
- alembic -c migrations/alembic.ini upgrade head
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d11d33f71c832685c2fbd25cff326f