### PR TITLE
fix(migrations): boolean server_defaults true/false + shorten revision ids (<=32)

### DIFF
--- a/migrations/versions/20250916_add_force_change_password.py
+++ b/migrations/versions/20250916_add_force_change_password.py
@@ -3,7 +3,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # OJO: deja estos IDs como los tienes en tu repo
-revision = "20250916_add_force_change_password"
+revision = "20250916_force_change_pw"
 down_revision = "20240201_create_users"
 branch_labels = None
 depends_on = None

--- a/migrations/versions/20250917_usernames.py
+++ b/migrations/versions/20250917_usernames.py
@@ -4,7 +4,7 @@ import sqlalchemy as sa
 
 # OJO: actualiza esto si tu down_revision real es otro
 revision = "20250917_usernames"
-down_revision = "20250916_add_force_change_password"
+down_revision = "20250916_force_change_pw"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- shorten the alembic revision id for the force_change_password migration to satisfy the 32 character limit
- update the dependent usernames migration to reference the shortened revision id

## Testing
- alembic -c migrations/alembic.ini history
- alembic -c migrations/alembic.ini upgrade head
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d120aa691483268bc8a2c4816658be