### PR TITLE
feat(ui): grid y botones uniformes + logout

### DIFF
--- a/app/blueprints/admin/templates/admin/bitacoras.html
+++ b/app/blueprints/admin/templates/admin/bitacoras.html
@@ -3,16 +3,20 @@
 {% block admin_content %}
 <h1>Bitácoras</h1>
 
-<form class="row g-2 mb-3" method="post" action="{{ url_for('admin.bitacoras_create') }}" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:.5rem">
+<form method="post" action="{{ url_for('admin.bitacoras_create') }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-  <select class="form-select" name="project_id" required>
-    <option value="">Proyecto…</option>
-    {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
-  </select>
-  <input class="form-control" name="author" placeholder="Autor (opcional)">
-  <input class="form-control" name="date" type="date" value="{{ (now or none)|default('', true) }}">
-  <textarea class="form-control" name="text" placeholder="Descripción..." style="grid-column:1/-1" required></textarea>
-  <div><button class="btn btn-primary">Guardar bitácora</button></div>
+  <div class="form-grid">
+    <select name="project_id" required>
+      <option value="">Proyecto…</option>
+      {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
+    </select>
+
+    <input type="text" name="author" placeholder="Autor (opcional)">
+    <input type="date" name="date" value="{{ (now or none)|default('', true) }}">
+    <textarea name="text" placeholder="Descripción…" required></textarea>
+
+    <button type="submit" class="btn btn-primary btn-wide">Guardar bitácora</button>
+  </div>
 </form>
 
 <table class="table">

--- a/app/blueprints/admin/templates/admin/users.html
+++ b/app/blueprints/admin/templates/admin/users.html
@@ -1,63 +1,64 @@
 {% extends "admin/_base_admin.html" %}
 {% block admin_content %}
 <h1>Usuarios</h1>
-<p><a class="btn btn-secondary" href="{{ url_for('admin.admin_new_user') }}">➕ Crear usuario</a></p>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Usuario</th>
-      <th>Rol</th>
-      <th>Activo</th>
-      <th>Cambiar rol</th>
-      <th>Alternar</th>
-      <th>Acciones</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for u in users %}
-    <tr>
-      <td>
-        <div class="fw-bold">{{ u.username }}</div>
-        <div class="text-muted">{{ u.email or '—' }}</div>
-      </td>
-      <td><span class="badge">{{ u.role or 'viewer' }}</span></td>
-      <td>{{ 'Sí' if u.is_active else 'No' }}</td>
-      <td>
-        <form method="post" action="{{ url_for('admin.users_set_role') }}" style="display:flex;gap:.4rem">
+<div class="stack-v">
+  <div class="toolbar">
+    <a href="{{ url_for('admin.admin_new_user') }}" class="btn btn-primary btn-wide">➕ Crear usuario</a>
+  </div>
+
+  <div class="table-grid header-6">
+    <div class="th">Usuario</div>
+    <div class="th">Rol</div>
+    <div class="th">Activo</div>
+    <div class="th">Cambiar rol</div>
+    <div class="th">Alternar</div>
+    <div class="th">Acciones</div>
+
+    {% for u in users %}
+      <div>
+        <div>{{ u.username }}</div>
+        <small>{{ u.email or '—' }}</small>
+      </div>
+
+      <div>{{ u.role or 'viewer' }}</div>
+
+      <div>{{ 'Sí' if u.is_active else 'No' }}</div>
+
+      <div class="btn-group">
+        <form method="post" action="{{ url_for('admin.users_set_role') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="user_id" value="{{ u.id }}">
-          <select name="role" class="form-select">
+          <select name="role">
             {% for r in ROLES %}
-              <option value="{{ r }}" {% if (u.role or 'viewer')==r %}selected{% endif %}>{{ r }}</option>
+              <option value="{{ r }}" {{ 'selected' if (u.role or 'viewer') == r else '' }}>{{ r }}</option>
             {% endfor %}
           </select>
-          <button class="btn btn-primary">Guardar</button>
+          <button class="btn btn-outline btn-wide" type="submit">Guardar</button>
         </form>
-      </td>
-      <td>
+      </div>
+
+      <div class="btn-group">
         <form method="post" action="{{ url_for('admin.users_toggle_active') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="user_id" value="{{ u.id }}">
-          <button class="btn btn-outline">{{ 'Desactivar' if u.is_active else 'Activar' }}</button>
+          <button class="btn btn-outline btn-wide" type="submit">{{ 'Desactivar' if u.is_active else 'Activar' }}</button>
         </form>
-      </td>
-      <td>
-        <div style="display:flex;gap:.4rem">
-          <form method="post" action="{{ url_for('admin.admin_user_reset_link', user_id=u.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button class="btn btn-outline-secondary">Enviar reset</button>
-          </form>
-          <form method="post" action="{{ url_for('admin.admin_user_toggle_force', user_id=u.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button class="btn btn-outline-secondary">
-              {{ 'Quitar forzar' if u.force_change_password else 'Forzar cambio' }}
-            </button>
-          </form>
-        </div>
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+      </div>
+
+      <div class="btn-group">
+        <form method="post" action="{{ url_for('admin.admin_user_reset_link', user_id=u.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button class="btn btn-outline btn-sm btn-wide" type="submit">Enviar reset</button>
+        </form>
+        <form method="post" action="{{ url_for('admin.admin_user_toggle_force', user_id=u.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button class="btn btn-outline btn-sm btn-wide" type="submit">
+            {{ 'Quitar forzar' if u.force_change_password else 'Forzar cambio' }}
+          </button>
+        </form>
+      </div>
+    {% endfor %}
+  </div>
+</div>
 {% endblock %}

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,0 +1,56 @@
+:root{
+  --gap:12px;
+  --gap-lg:16px;
+  --radius:12px;
+  --btn-h:42px;
+  --fw:600;
+}
+
+*{box-sizing:border-box;}
+
+.btn, button, input[type="submit"]{
+  display:inline-flex; align-items:center; justify-content:center;
+  height:var(--btn-h); padding:0 14px; gap:8px;
+  border-radius:var(--radius); font-weight:var(--fw);
+  line-height:1; text-decoration:none; cursor:pointer;
+}
+
+.btn-primary{ background:#24a0ff; color:#09111f; border:1px solid transparent; }
+.btn-outline{ background:transparent; color:#cfe8ff; border:1px solid #2b3a50; }
+.btn-danger{ background:#ef4444; color:#fff; border:1px solid transparent; }
+.btn-ghost{ background:transparent; color:#cfe8ff; border:1px solid transparent; }
+
+.btn-group{ display:flex; flex-wrap:wrap; gap:var(--gap); align-items:center; }
+.btn-group form{ display:flex; flex-wrap:wrap; gap:var(--gap); align-items:center; }
+.btn-wide{ min-width:132px; }
+.btn-sm{ height:36px; padding:0 12px; }
+.btn-block{ width:100%; }
+
+input[type="text"],input[type="email"],input[type="date"],select,textarea{
+  border:1px solid #2b3a50; background:#0f1725; color:#dbe8ff;
+  border-radius:var(--radius); padding:10px 12px; height:var(--btn-h);
+}
+textarea{ min-height:var(--btn-h); height:auto; }
+
+.toolbar{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }
+.stack-v{ display:flex; flex-direction:column; gap:var(--gap); }
+.stack-h{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }
+
+/* Grid de “tabla” utilizada en Admin/Usuarios */
+.table-grid{ display:grid; gap:var(--gap); align-items:center; }
+.table-grid.header-6{ grid-template-columns: 1.4fr .8fr .6fr 1fr 1fr 1.2fr; }
+.table-grid > .th{ font-weight:var(--fw); opacity:.85; }
+.table-grid .row{ display:contents; }
+
+/* Formularios horizontales (Bitácoras) */
+.form-grid{
+  display:grid;
+  grid-template-columns: 220px 220px 180px minmax(280px,1fr) 160px;
+  gap:var(--gap); align-items:center;
+}
+
+@media (max-width: 900px){
+  .table-grid.header-6{ grid-template-columns:1fr; }
+  .form-grid{ grid-template-columns:1fr; }
+  .btn-wide{ width:100%; }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>{% block title %}SGC — Obra de Dragado{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}?v=2">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body>
   <header class="navbar">
@@ -15,8 +16,15 @@
       </span>
     </div>
     <nav class="nav-right">
-      <a class="btn" href="{{ url_for('auth.login') }}">Login</a>
-      <a class="btn outline" href="{{ url_for('admin.dashboard') }}">Admin</a>
+      {% set is_logged = current_user.is_authenticated or session.get('user') %}
+      <div class="toolbar" style="margin-left:auto">
+        {% if is_logged %}
+          <a class="btn btn-outline" href="{{ url_for('admin.dashboard') }}">Admin</a>
+          <a class="btn btn-primary" href="{{ url_for('auth.logout') }}">Logout</a>
+        {% else %}
+          <a class="btn btn-primary" href="{{ url_for('auth.login') }}">Login</a>
+        {% endif %}
+      </div>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- add a shared UI stylesheet for buttons, form grids, and responsive table layouts
- update the base layout/navbar to load the new styles and surface the logout action
- restyle admin users and bitácoras views to use the new grid/button patterns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1329ffdd48326b695472260cdbcb9