### PR TITLE
feat(ui): iconos inline y estados

### DIFF
--- a/app/blueprints/admin/templates/admin/bitacoras.html
+++ b/app/blueprints/admin/templates/admin/bitacoras.html
@@ -1,18 +1,26 @@
 {% extends "admin/_base_admin.html" %}
+{% import "_icons.html" as i %}
 {% block admin_title %}Bitácoras · Admin · SGC{% endblock %}
 {% block admin_content %}
+{% set default_date = now.isoformat() if now else '' %}
 <h1>Bitácoras</h1>
 
-<form class="row g-2 mb-3" method="post" action="{{ url_for('admin.bitacoras_create') }}" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:.5rem">
+<form method="post" action="{{ url_for('admin.bitacoras_create') }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-  <select class="form-select" name="project_id" required>
-    <option value="">Proyecto…</option>
-    {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
-  </select>
-  <input class="form-control" name="author" placeholder="Autor (opcional)">
-  <input class="form-control" name="date" type="date" value="{{ (now or none)|default('', true) }}">
-  <textarea class="form-control" name="text" placeholder="Descripción..." style="grid-column:1/-1" required></textarea>
-  <div><button class="btn btn-primary">Guardar bitácora</button></div>
+  <div class="form-grid">
+    <select name="project_id" required aria-label="Proyecto">
+      <option value="">Proyecto…</option>
+      {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
+    </select>
+
+    <input type="text" name="author" placeholder="Autor (opcional)" aria-label="Autor">
+    <input type="date" name="date" value="{{ default_date }}" aria-label="Fecha">
+    <textarea name="text" placeholder="Descripción…" aria-label="Descripción" required></textarea>
+
+    <button type="submit" class="btn btn-primary btn-wide" title="Guardar bitácora">
+      {{ i.save() }} <span>Guardar bitácora</span>
+    </button>
+  </div>
 </form>
 
 <table class="table">

--- a/app/blueprints/admin/templates/admin/users.html
+++ b/app/blueprints/admin/templates/admin/users.html
@@ -1,63 +1,73 @@
 {% extends "admin/_base_admin.html" %}
+{% import "_icons.html" as i %}
 {% block admin_content %}
 <h1>Usuarios</h1>
-<p><a class="btn btn-secondary" href="{{ url_for('admin.admin_new_user') }}">➕ Crear usuario</a></p>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Usuario</th>
-      <th>Rol</th>
-      <th>Activo</th>
-      <th>Cambiar rol</th>
-      <th>Alternar</th>
-      <th>Acciones</th>
-    </tr>
-  </thead>
-  <tbody>
-  {% for u in users %}
-    <tr>
-      <td>
-        <div class="fw-bold">{{ u.username }}</div>
-        <div class="text-muted">{{ u.email or '—' }}</div>
-      </td>
-      <td><span class="badge">{{ u.role or 'viewer' }}</span></td>
-      <td>{{ 'Sí' if u.is_active else 'No' }}</td>
-      <td>
-        <form method="post" action="{{ url_for('admin.users_set_role') }}" style="display:flex;gap:.4rem">
+<div class="stack-v">
+  <div class="toolbar">
+    <a href="{{ url_for('admin.admin_new_user') }}" class="btn btn-primary btn-wide" title="Crear usuario">
+      {{ i.plus() }} <span>Crear usuario</span>
+    </a>
+  </div>
+
+  <div class="table-grid header-6">
+    <div class="th">Usuario</div>
+    <div class="th">Rol</div>
+    <div class="th">Activo</div>
+    <div class="th">Cambiar rol</div>
+    <div class="th">Alternar</div>
+    <div class="th">Acciones</div>
+
+    {% for u in users %}
+      <div>
+        <div>{{ u.username }}</div>
+        <small>{{ u.email or '—' }}</small>
+      </div>
+
+      <div>{{ u.role or 'viewer' }}</div>
+
+      <div>{{ 'Sí' if u.is_active else 'No' }}</div>
+
+      <div class="btn-group">
+        <form method="post" action="{{ url_for('admin.users_set_role') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="user_id" value="{{ u.id }}">
-          <select name="role" class="form-select">
+          <select name="role" aria-label="Rol de {{ u.username }}">
             {% for r in ROLES %}
               <option value="{{ r }}" {% if (u.role or 'viewer')==r %}selected{% endif %}>{{ r }}</option>
             {% endfor %}
           </select>
-          <button class="btn btn-primary">Guardar</button>
+          <button class="btn btn-outline btn-wide" type="submit" title="Guardar rol de {{ u.username }}">
+            {{ i.save() }} <span>Guardar</span>
+          </button>
         </form>
-      </td>
-      <td>
+      </div>
+
+      <div class="btn-group">
         <form method="post" action="{{ url_for('admin.users_toggle_active') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="user_id" value="{{ u.id }}">
-          <button class="btn btn-outline">{{ 'Desactivar' if u.is_active else 'Activar' }}</button>
+          <button class="btn btn-outline btn-wide" type="submit" title="{{ 'Desactivar' if u.is_active else 'Activar' }} usuario {{ u.username }}">
+            {{ i.power() }} <span>{{ 'Desactivar' if u.is_active else 'Activar' }}</span>
+          </button>
         </form>
-      </td>
-      <td>
-        <div style="display:flex;gap:.4rem">
-          <form method="post" action="{{ url_for('admin.admin_user_reset_link', user_id=u.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button class="btn btn-outline-secondary">Enviar reset</button>
-          </form>
-          <form method="post" action="{{ url_for('admin.admin_user_toggle_force', user_id=u.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button class="btn btn-outline-secondary">
-              {{ 'Quitar forzar' if u.force_change_password else 'Forzar cambio' }}
-            </button>
-          </form>
-        </div>
-      </td>
-    </tr>
-  {% endfor %}
-  </tbody>
-</table>
+      </div>
+
+      <div class="btn-group">
+        <form method="post" action="{{ url_for('admin.admin_user_reset_link', user_id=u.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button class="btn btn-outline btn-sm btn-wide" type="submit" title="Enviar email de reseteo">
+            {{ i.refresh() }} <span>Enviar reset</span>
+          </button>
+        </form>
+        <form method="post" action="{{ url_for('admin.admin_user_toggle_force', user_id=u.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button class="btn btn-outline btn-sm btn-wide" type="submit" title="{{ 'Quitar forzar cambio de contraseña' if u.force_change_password else 'Forzar cambio de contraseña' }}">
+            {{ i.key() }} <span>{{ 'Quitar forzar' if u.force_change_password else 'Forzar cambio' }}</span>
+          </button>
+        </form>
+      </div>
+    {% endfor %}
+  </div>
+</div>
 {% endblock %}

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,0 +1,87 @@
+/* ==== Theme tokens ==== */
+:root{
+  --gap:12px;
+  --gap-lg:16px;
+  --radius:12px;
+  --btn-h:42px;
+  --fw:600;
+
+  --c-bg:#0b1422;
+  --c-panel:#0f1725;
+  --c-text:#dbe8ff;
+  --c-muted:#9fb3cf;
+
+  --c-primary:#24a0ff;
+  --c-primary-ink:#08111d;
+  --c-outline:#2b3a50;
+  --c-danger:#ef4444;
+  --ring:#63b3ff80; /* 50% alpha */
+}
+
+*{ box-sizing:border-box; }
+body{ background:var(--c-bg); color:var(--c-text); }
+
+/* ==== Buttons ==== */
+.btn, button, input[type="submit"]{
+  display:inline-flex; align-items:center; justify-content:center;
+  height:var(--btn-h); padding:0 14px; gap:8px;
+  border-radius:var(--radius); font-weight:var(--fw);
+  line-height:1; text-decoration:none; cursor:pointer;
+  border:1px solid transparent; transition: transform .04s ease, box-shadow .12s ease, background-color .12s ease, border-color .12s ease;
+  user-select:none;
+}
+
+.btn-primary{ background:var(--c-primary); color:var(--c-primary-ink); }
+.btn-outline{ background:transparent; color:var(--c-text); border-color:var(--c-outline); }
+.btn-danger{ background:var(--c-danger); color:#fff; }
+.btn-ghost{ background:transparent; color:var(--c-text); }
+
+.btn:hover{ filter:brightness(1.03); }
+.btn:active{ transform:translateY(1px); }
+.btn:focus-visible{
+  outline:none; box-shadow:0 0 0 3px var(--ring);
+}
+.btn[disabled], .btn:disabled{ opacity:.6; cursor:not-allowed; filter:none; transform:none; }
+
+/* sizes / groups */
+.btn-group{ display:flex; flex-wrap:wrap; gap:var(--gap); align-items:center; }
+.btn-wide{ min-width:132px; }
+.btn-sm{ height:36px; padding:0 12px; }
+
+.icon{ width:18px; height:18px; display:inline-block; }
+.icon > svg{ width:100%; height:100%; display:block; }
+
+/* ==== Inputs ==== */
+input[type="text"], input[type="email"], input[type="date"], select, textarea{
+  border:1px solid var(--c-outline); background:var(--c-panel); color:var(--c-text);
+  border-radius:var(--radius); padding:10px 12px; height:var(--btn-h);
+}
+textarea{ min-height:var(--btn-h); height:auto; }
+input:focus-visible, select:focus-visible, textarea:focus-visible{
+  outline:none; box-shadow:0 0 0 3px var(--ring);
+}
+
+/* ==== Layout helpers ==== */
+.toolbar{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }
+.stack-v{ display:flex; flex-direction:column; gap:var(--gap); }
+.stack-h{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }
+
+/* Admin/Usuarios tabla-Grid */
+.table-grid{ display:grid; gap:var(--gap); align-items:center; }
+.table-grid.header-6{ grid-template-columns: 1.4fr .8fr .6fr 1fr 1fr 1.2fr; }
+.table-grid > .th{ font-weight:var(--fw); color:var(--c-muted); }
+.table-grid .row{ display:contents; }
+
+/* Bitácoras form */
+.form-grid{
+  display:grid;
+  grid-template-columns: 220px 220px 180px minmax(280px,1fr) 180px;
+  gap:var(--gap); align-items:center;
+}
+
+/* Responsive */
+@media (max-width: 900px){
+  .table-grid.header-6{ grid-template-columns:1fr; }
+  .form-grid{ grid-template-columns:1fr; }
+  .btn-wide{ width:100%; }
+}

--- a/app/templates/_icons.html
+++ b/app/templates/_icons.html
@@ -1,0 +1,62 @@
+{% macro plus(cls="icon") -%}
+<span class="{{ cls }}" aria-hidden="true">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M12 5v14M5 12h14"/>
+  </svg>
+</span>
+{%- endmacro %}
+
+{% macro save(cls="icon") -%}
+<span class="{{ cls }}" aria-hidden="true">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2Z"/>
+    <path d="M17 21v-8H7v8M7 3v5h8"/>
+  </svg>
+</span>
+{%- endmacro %}
+
+{% macro power(cls="icon") -%}
+<span class="{{ cls }}" aria-hidden="true">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M12 2v10"/>
+    <path d="M19.1 4.9a10 10 0 1 1-14.2 0"/>
+  </svg>
+</span>
+{%- endmacro %}
+
+{% macro refresh(cls="icon") -%}
+<span class="{{ cls }}" aria-hidden="true">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M21 12a9 9 0 1 1-3-6.7"/>
+    <path d="M21 3v6h-6"/>
+  </svg>
+</span>
+{%- endmacro %}
+
+{% macro key(cls="icon") -%}
+<span class="{{ cls }}" aria-hidden="true">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <circle cx="7.5" cy="15.5" r="3.5"/>
+    <path d="M10.8 12.2 21 2v4h-3v3h-3v3h-4.2Z"/>
+  </svg>
+</span>
+{%- endmacro %}
+
+{% macro logout(cls="icon") -%}
+<span class="{{ cls }}" aria-hidden="true">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+    <path d="M16 17l5-5-5-5"/>
+    <path d="M21 12H9"/>
+  </svg>
+</span>
+{%- endmacro %}
+
+{% macro userShield(cls="icon") -%}
+<span class="{{ cls }}" aria-hidden="true">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5Z"/>
+    <path d="M2 22a8 8 0 0 1 16 0"/>
+  </svg>
+</span>
+{%- endmacro %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,8 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>{% block title %}SGC — Obra de Dragado{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}?v=2">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body>
+  {% import "_icons.html" as i %}
   <header class="navbar">
     <div class="nav-left">
       <span class="brand">
@@ -14,10 +16,22 @@
         <span>SGC-Obra</span>
       </span>
     </div>
-    <nav class="nav-right">
-      <a class="btn" href="{{ url_for('auth.login') }}">Login</a>
-      <a class="btn outline" href="{{ url_for('admin.dashboard') }}">Admin</a>
-    </nav>
+    {% set simple_user = session.get('user') %}
+    {% set is_authenticated = current_user.is_authenticated or simple_user %}
+    <div class="toolbar" style="margin-left:auto">
+      {% if is_authenticated %}
+        <a class="btn btn-outline" href="{{ url_for('admin.index') }}" title="Panel de administración" aria-label="Admin">
+          {{ i.userShield() }} <span>Admin</span>
+        </a>
+        <a class="btn btn-primary" href="{{ url_for('auth.logout') }}" title="Cerrar sesión" aria-label="Logout">
+          {{ i.logout() }} <span>Logout</span>
+        </a>
+      {% else %}
+        <a class="btn btn-primary" href="{{ url_for('auth.login') }}" title="Iniciar sesión" aria-label="Login">
+          {{ i.key() }} <span>Login</span>
+        </a>
+      {% endif %}
+    </div>
   </header>
 
   <main class="container">


### PR DESCRIPTION
## Summary
- add shared theme tokens and button styles with accessible focus ring
- expose inline SVG icon macros and use them on the navbar actions
- refresh admin users and bitácoras controls with icon buttons and responsive helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1351625e48326b3e24b27fe641724