### PR TITLE
Integrate new admin styles and icon macros

### DIFF
--- a/app/blueprints/admin/routes.py
+++ b/app/blueprints/admin/routes.py
@@ -183,7 +183,10 @@ def bitacoras():
     )
     projects = Project.query.order_by(Project.name).all()
     return render_template(
-        "admin/bitacoras.html", logs=logs, projects=projects, now=date.today()
+        "admin/bitacoras.html",
+        logs=logs,
+        projects=projects,
+        default_date=date.today().isoformat(),
     )
 
 

--- a/app/blueprints/admin/templates/admin/bitacoras.html
+++ b/app/blueprints/admin/templates/admin/bitacoras.html
@@ -1,4 +1,5 @@
 {% extends "admin/_base_admin.html" %}
+{% import "_icons.html" as i %}
 {% block admin_title %}Bitácoras · Admin · SGC{% endblock %}
 {% block admin_content %}
 <h1>Bitácoras</h1>
@@ -6,16 +7,18 @@
 <form method="post" action="{{ url_for('admin.bitacoras_create') }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <div class="form-grid">
-    <select name="project_id" required>
+    <select name="project_id" required aria-label="Proyecto">
       <option value="">Proyecto…</option>
       {% for p in projects %}<option value="{{ p.id }}">{{ p.name }}</option>{% endfor %}
     </select>
 
-    <input type="text" name="author" placeholder="Autor (opcional)">
-    <input type="date" name="date" value="{{ (now or none)|default('', true) }}">
-    <textarea name="text" placeholder="Descripción…" required></textarea>
+    <input type="text" name="author" placeholder="Autor (opcional)" aria-label="Autor">
+    <input type="date" name="date" value="{{ default_date }}" aria-label="Fecha">
+    <textarea name="text" placeholder="Descripción…" aria-label="Descripción" required></textarea>
 
-    <button type="submit" class="btn btn-primary btn-wide">Guardar bitácora</button>
+    <button type="submit" class="btn btn-primary btn-wide" title="Guardar bitácora">
+      {{ i.save() }} <span>Guardar bitácora</span>
+    </button>
   </div>
 </form>
 

--- a/app/blueprints/admin/templates/admin/users.html
+++ b/app/blueprints/admin/templates/admin/users.html
@@ -1,4 +1,5 @@
 {% extends "admin/_base_admin.html" %}
+{% import "_icons.html" as i %}
 {% block admin_content %}
 <h1>Usuarios</h1>
 
@@ -34,7 +35,9 @@
               <option value="{{ r }}" {{ 'selected' if (u.role or 'viewer') == r else '' }}>{{ r }}</option>
             {% endfor %}
           </select>
-          <button class="btn btn-outline btn-wide" type="submit">Guardar</button>
+          <button class="btn btn-outline btn-wide" type="submit" title="Guardar rol">
+            {{ i.save() }} <span>Guardar</span>
+          </button>
         </form>
       </div>
 
@@ -42,19 +45,23 @@
         <form method="post" action="{{ url_for('admin.users_toggle_active') }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
           <input type="hidden" name="user_id" value="{{ u.id }}">
-          <button class="btn btn-outline btn-wide" type="submit">{{ 'Desactivar' if u.is_active else 'Activar' }}</button>
+          <button class="btn btn-outline btn-wide" type="submit" title="{{ 'Desactivar' if u.is_active else 'Activar' }} usuario {{ u.username }}">
+            {{ i.power() }} <span>{{ 'Desactivar' if u.is_active else 'Activar' }}</span>
+          </button>
         </form>
       </div>
 
       <div class="btn-group">
         <form method="post" action="{{ url_for('admin.admin_user_reset_link', user_id=u.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button class="btn btn-outline btn-sm btn-wide" type="submit">Enviar reset</button>
+          <button class="btn btn-outline btn-sm btn-wide" type="submit" title="Enviar reset">
+            {{ i.refresh() }} <span>Enviar reset</span>
+          </button>
         </form>
         <form method="post" action="{{ url_for('admin.admin_user_toggle_force', user_id=u.id) }}">
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button class="btn btn-outline btn-sm btn-wide" type="submit">
-            {{ 'Quitar forzar' if u.force_change_password else 'Forzar cambio' }}
+          <button class="btn btn-outline btn-sm btn-wide" type="submit" title="{{ 'Quitar forzar' if u.force_change_password else 'Forzar cambio' }}">
+            {{ i.key() }} <span>{{ 'Quitar forzar' if u.force_change_password else 'Forzar cambio' }}</span>
           </button>
         </form>
       </div>

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,3 +1,57 @@
+body { font-family: Arial, sans-serif; margin:0; background:#0b1220; color:#e8eefb; }
+a { text-decoration:none; }
+.sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
+
+.navbar{
+  position:sticky;top:0;z-index:10;
+  display:flex;align-items:center;justify-content:space-between;
+  padding:12px 18px;border-bottom:1px solid var(--border, #223454);
+  background:rgba(11,18,32,0.85);backdrop-filter:blur(6px)
+}
+.nav-left .brand{
+  display:inline-flex;align-items:center;gap:10px;
+  font-weight:600;letter-spacing:.3px
+}
+.nav-left .brand .logo{
+  height:24px;width:auto;display:block;border-radius:4px;
+  box-shadow:0 0 0 1px rgba(255,255,255,.06);
+}
+
+.nav-right{display:flex;gap:10px}
+.btn{
+  padding:8px 14px;border-radius:10px;
+  background:var(--accent, #33b1ff);color:#001726;font-weight:600;
+  border:1px solid transparent;transition:.2s
+}
+.btn:hover{filter:brightness(1.05)}
+.btn.outline{
+  background:transparent;border-color:var(--border, #223454);color:var(--text, #e8eefb)
+}
+.btn.outline:hover{background:rgba(18,26,42,.6)}
+
+.container { max-width:1100px; margin:28px auto; padding:0 16px; }
+.hero h1 { font-size:28px; margin-bottom:4px; }
+.muted { color:#9fb2d0; }
+
+.grid { display:grid; gap:14px; grid-template-columns:repeat(auto-fit, minmax(250px,1fr)); }
+.card { background:#141e31; padding:16px; border-radius:10px; border:1px solid #223454; }
+.card:hover { background:#1a2640; }
+.card h3 { margin:0 0 6px; font-size:16px; }
+.card p { margin:0; color:#9fb2d0; font-size:14px; }
+
+.about { margin-top:28px; }
+.external-link { display:inline-block; margin-top:10px; color:#33b1ff; font-weight:600; }
+.external-link:hover { text-decoration:underline; }
+
+.footer { margin:28px auto; text-align:center; color:#9fb2d0; }
+
+.auth-wrap{
+  max-width:640px;margin:48px auto;padding:24px;
+  background:rgba(20,30,49,.6);border:1px solid var(--border,#223454);border-radius:12px
+}
+.auth-wrap h1{margin:0 0 16px;font-size:24px}
+/* ci: touch for PR test */
+
 :root{
   --gap:12px;
   --gap-lg:16px;
@@ -32,6 +86,20 @@ input[type="text"],input[type="email"],input[type="date"],select,textarea{
 }
 textarea{ min-height:var(--btn-h); height:auto; }
 
+.btn svg{ width:18px; height:18px; }
+.btn span{ display:inline-flex; align-items:center; }
+
+.icon{ display:block; }
+
+:focus-visible{ outline:2px solid rgba(36,160,255,0.9); outline-offset:2px; }
+.btn:focus-visible,
+button:focus-visible,
+input[type="submit"]:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+input:focus-visible{
+  box-shadow:0 0 0 3px rgba(36,160,255,0.35);
+}
 .toolbar{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }
 .stack-v{ display:flex; flex-direction:column; gap:var(--gap); }
 .stack-h{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }

--- a/app/templates/_icons.html
+++ b/app/templates/_icons.html
@@ -1,0 +1,54 @@
+{% macro icon(view_box='0 0 24 24', width=18, height=18) -%}
+<svg class="icon" width="{{ width }}" height="{{ height }}" viewBox="{{ view_box }}" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg">
+  {{ caller() }}
+</svg>
+{%- endmacro %}
+
+{% macro save() -%}
+{%- call icon() -%}
+  <path d="M6 3h9l4 4v12a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z" />
+  <path d="M12 7v7" />
+  <path d="M9.5 11.5L12 14l2.5-2.5" />
+{%- endcall %}
+{%- endmacro %}
+
+{% macro logout() -%}
+{%- call icon() -%}
+  <path d="M16 7l5 5-5 5" />
+  <path d="M21 12H10" />
+  <path d="M13 5H8a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h5" />
+{%- endcall %}
+{%- endmacro %}
+
+{% macro key() -%}
+{%- call icon() -%}
+  <circle cx="9" cy="12" r="3" />
+  <path d="M12 12h8" />
+  <path d="M18 9v6" />
+  <path d="M15 9v6" />
+{%- endcall %}
+{%- endmacro %}
+
+{% macro power() -%}
+{%- call icon() -%}
+  <path d="M12 3v9" />
+  <path d="M7 6.5a7 7 0 1 0 10 0" />
+{%- endcall %}
+{%- endmacro %}
+
+{% macro refresh() -%}
+{%- call icon() -%}
+  <path d="M20 11V5h-6" />
+  <path d="M4 13v6h6" />
+  <path d="M6.5 17.5a7 7 0 0 0 11.5-3" />
+  <path d="M17.5 6.5a7 7 0 0 0-11.5 3" />
+{%- endcall %}
+{%- endmacro %}
+
+{% macro userShield() -%}
+{%- call icon() -%}
+  <path d="M12 3l7 3v6c0 5-3.5 9.5-7 10.5-3.5-1-7-5.5-7-10.5V6z" />
+  <path d="M12 10a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" />
+  <path d="M8 18a4.5 4.5 0 0 1 8 0" />
+{%- endcall %}
+{%- endmacro %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html lang="es">
+{% import "_icons.html" as i %}
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>{% block title %}SGC — Obra de Dragado{% endblock %}</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}?v=2">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body>
@@ -19,10 +19,16 @@
       {% set is_logged = current_user.is_authenticated or session.get('user') %}
       <div class="toolbar" style="margin-left:auto">
         {% if is_logged %}
-          <a class="btn btn-outline" href="{{ url_for('admin.dashboard') }}">Admin</a>
-          <a class="btn btn-primary" href="{{ url_for('auth.logout') }}">Logout</a>
+          <a class="btn btn-outline" href="{{ url_for('admin.dashboard') }}">
+            {{ i.userShield() }} <span>Admin</span>
+          </a>
+          <a class="btn btn-primary" href="{{ url_for('auth.logout') }}">
+            {{ i.logout() }} <span>Logout</span>
+          </a>
         {% else %}
-          <a class="btn btn-primary" href="{{ url_for('auth.login') }}">Login</a>
+          <a class="btn btn-primary" href="{{ url_for('auth.login') }}">
+            {{ i.key() }} <span>Login</span>
+          </a>
         {% endif %}
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- merge the legacy custom styles and new token-based admin styles into `app/static/css/app.css`, adding focus-visible and icon helpers
- introduce shared SVG icon macros and update the base layout plus admin bitácoras/users templates to render icon-enhanced buttons with accessibility tweaks
- provide a default ISO date for the bitácoras form to keep the new markup functional

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d13bec33b08326bf11e3c9133198eb