### PR TITLE
Implement invite-based registration and admin navbar updates

### DIFF
--- a/app/blueprints/admin/templates/admin/_base_admin.html
+++ b/app/blueprints/admin/templates/admin/_base_admin.html
@@ -1,22 +1,32 @@
 {% extends "base.html" %}
-{% block title %}{% block admin_title %}SGC · Admin{% endblock %}{% endblock %}
+{% block admin_title %}{% if self.title() %}{% block title %}{% endblock %}{% else %}Admin · SGC{% endif %}{% endblock %}
+
 {% block content %}
-<div class="admin-layout">
-  <aside class="admin-sidebar">
-    <div class="brand">SGC · Admin</div>
-    <nav>
-      <a href="{{ url_for('admin.index') }}">📊 Dashboard</a>
-      <a href="{{ url_for('admin.projects') }}">🏗️ Proyectos</a>
-      <a href="{{ url_for('admin.bitacoras') }}">📝 Bitácoras</a>
-      <a href="{{ url_for('admin.checklists') }}">✅ Checklists</a>
-      <a href="{{ url_for('admin.users') }}">👤 Usuarios</a>
-      {% if current_user.is_authenticated and (current_user.role is defined) and current_user.role == 'admin' %}
-        <a href="{{ url_for('admin.users_pending') }}">⏳ Pendientes</a>
+  {% block admin_header %}
+  <nav class="toolbar stack-h" style="gap:.5rem; flex-wrap:wrap;">
+    <a class="btn btn-outline" href="{{ admin_url('admin.dashboard', 'admin.index') }}">Dashboard</a>
+    <a class="btn btn-outline" href="{{ admin_url('admin.projects_index', 'admin.projects') }}">Proyectos</a>
+    <a class="btn btn-outline" href="{{ admin_url('admin.bitacoras_index', 'admin.bitacoras') }}">Bitácoras</a>
+    <a class="btn btn-outline" href="{{ admin_url('admin.checklists_index', 'admin.checklists') }}">Checklists</a>
+    <a class="btn btn-outline" href="{{ admin_url('admin.users_index', 'admin.users') }}">Usuarios</a>
+
+    {% if current_user.is_authenticated and current_user.role == 'admin' %}
+      <a class="btn btn-outline" href="{{ admin_url('admin.users_pending') }}">Pendientes</a>
+      {% if has_admin_endpoint('admin.invites_index') %}
+        <a class="btn btn-outline" href="{{ admin_url('admin.invites_index') }}">Invitaciones</a>
       {% endif %}
-    </nav>
-  </aside>
-  <main class="admin-main">
-    {% block admin_content %}{% endblock %}
-  </main>
-</div>
+    {% endif %}
+
+    <span class="flex-1"></span>
+
+    {% if current_user.is_authenticated %}
+      <form method="post" action="{{ url_for('auth.logout') }}">
+        {{ csrf_token() }}
+        <button class="btn btn-primary">Logout</button>
+      </form>
+    {% endif %}
+  </nav>
+  {% endblock %}
+
+  {% block admin_content %}{% endblock %}
 {% endblock %}

--- a/app/blueprints/auth/templates/auth/register.html
+++ b/app/blueprints/auth/templates/auth/register.html
@@ -1,33 +1,39 @@
 {% extends "base.html" %}
-{% block title %}Crear usuario - SGC{% endblock %}
 
 {% block content %}
-<div class="container py-4" style="max-width:640px">
-  <h1 class="mb-3">Crear un nuevo usuario</h1>
-  <p class="text-muted">Solo usuario y contraseña (sin correo).</p>
-  <div class="alert alert-info" role="status">
-    Una vez que un administrador valide tu cuenta, podrás acceder.
+<h1>Crear cuenta</h1>
+
+<form method="post" class="stack-v" style="gap:.75rem; max-width:520px;">
+  {{ csrf_token() }}
+
+  {% if invite %}
+    <input type="hidden" name="token" value="{{ request.args.get('token','') }}">
+  {% endif %}
+
+  <label class="stack-v">
+    <span class="th">Usuario</span>
+    <input name="username" required minlength="3" maxlength="32" placeholder="tu_usuario">
+  </label>
+
+  <label class="stack-v">
+    <span class="th">Email</span>
+    <input name="email" type="email" value="{{ invite.email if invite and invite.email else '' }}"
+           {% if invite and invite.email %}readonly{% endif %}
+           placeholder="tucorreo@empresa.com" required>
+  </label>
+
+  <label class="stack-v">
+    <span class="th">Contraseña</span>
+    <input name="password" type="password" required minlength="8" placeholder="••••••••">
+  </label>
+
+  <div class="stack-h" style="gap:.5rem;">
+    <button class="btn btn-primary">Crear cuenta</button>
+    <a class="btn btn-outline" href="{{ url_for('auth.login') }}">Ya tengo cuenta</a>
   </div>
 
-  <form method="post" action="{{ url_for('auth.register_post') }}">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <div class="mb-3">
-      <label class="form-label">Usuario</label>
-      <input type="text" name="username" class="form-control" required autofocus />
-    </div>
-
-    <div class="mb-3">
-      <label class="form-label">Contraseña</label>
-      <input type="password" name="password" class="form-control" required />
-    </div>
-
-    <div class="mb-4">
-      <label class="form-label">Confirmar contraseña</label>
-      <input type="password" name="confirm" class="form-control" required />
-    </div>
-
-    <button type="submit" class="btn btn-primary btn-lg">Crear usuario</button>
-    <a href="{{ url_for('auth.login') }}" class="btn btn-link">Volver al login</a>
-  </form>
-</div>
+  <p class="muted">
+    Tu cuenta quedará <b>pendiente de aprobación</b> por un administrador.
+  </p>
+</form>
 {% endblock %}

--- a/app/config.py
+++ b/app/config.py
@@ -72,6 +72,7 @@ class BaseConfig:
         seconds=int(os.getenv("REMEMBER_COOKIE_DURATION", "86400"))
     )
     LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+    SIGNUP_MODE = os.getenv("SIGNUP_MODE", "invite")
 
 
 class DevelopmentConfig(BaseConfig):
@@ -87,6 +88,7 @@ class TestingConfig(BaseConfig):
         **BaseConfig.SQLALCHEMY_ENGINE_OPTIONS,
         "connect_args": {"check_same_thread": False},
     }
+    SIGNUP_MODE = os.getenv("SIGNUP_MODE", "open")
 
 
 class ProductionConfig(BaseConfig):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -250,6 +250,7 @@ def load_user(user_id: str) -> User | None:
 
 from app.models.asset import Asset  # noqa: E402,F401
 from app.models.folder import Folder  # noqa: E402,F401
+from app.models.invite import Invite  # noqa: E402,F401
 
 
 __all__ = [
@@ -264,5 +265,6 @@ __all__ = [
     "DailyChecklist",
     "DailyChecklistItem",
     "Todo",
+    "Invite",
     "User",
 ]

--- a/app/models/invite.py
+++ b/app/models/invite.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db import db
+
+
+class Invite(db.Model):
+    __tablename__ = "invites"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    token: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    email: Mapped[str | None] = mapped_column(String(254), nullable=True)
+    created_by_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    max_uses: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    used_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+    created_by = relationship("User", backref="created_invites")
+
+    @property
+    def is_expired(self) -> bool:
+        return bool(self.expires_at and datetime.utcnow() > self.expires_at)
+
+    def deactivate(self) -> None:
+        self.is_active = False
+
+    def remaining_uses(self) -> int | None:
+        if self.max_uses is None:
+            return None
+        return max(self.max_uses - self.used_count, 0)
+
+    def record_use(self) -> None:
+        self.used_count += 1
+        if self.max_uses is not None and self.used_count >= self.max_uses:
+            self.is_active = False


### PR DESCRIPTION
## Summary
- update the admin blueprint imports and provide template helpers for the new toolbar links
- refresh the admin base layout and auth register form to support invite-driven signups
- introduce the Invite model and expose configuration toggles for signup modes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1509635c48326bf34cb2772b8c44e