### PR TITLE
feat: require POST logout with csrf

### DIFF
--- a/app/blueprints/admin/templates/admin/_base_admin.html
+++ b/app/blueprints/admin/templates/admin/_base_admin.html
@@ -18,13 +18,6 @@
     {% endif %}
 
     <span class="flex-1"></span>
-
-    {% if current_user.is_authenticated %}
-      <form method="post" action="{{ url_for('auth.logout') }}">
-        {{ csrf_token() }}
-        <button class="btn btn-primary">Logout</button>
-      </form>
-    {% endif %}
   </nav>
   {% endblock %}
 

--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -14,12 +14,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import (
-    current_user,
-    login_required as flask_login_required,
-    login_user,
-    logout_user,
-)
+from flask_login import current_user, login_required, login_user, logout_user
 from sqlalchemy import func
 
 from app.db import db
@@ -144,14 +139,12 @@ def login():
     return render_template("auth/login.html")
 
 
-@bp_auth.get("/logout")
+@bp_auth.post("/logout")
+@login_required
 def logout():
-    if current_app.config.get("AUTH_SIMPLE", True):
-        session.clear()
-        flash("Sesión cerrada.", "info")
-        return redirect(url_for("web.index"))
     logout_user()
-    flash("Sesión cerrada", "info")
+    session.clear()
+    flash("Sesión cerrada.", "info")
     return redirect(url_for("auth.login"))
 
 
@@ -214,7 +207,7 @@ def register_post():
     return redirect(url_for("auth.login"))
 
 @bp_auth.route("/change-password", methods=["GET", "POST"])
-@flask_login_required
+@login_required
 def change_password():
     force_change = getattr(current_user, "force_change_password", False)
     template = (

--- a/app/blueprints/auth/templates/auth/register.html
+++ b/app/blueprints/auth/templates/auth/register.html
@@ -4,7 +4,7 @@
 <h1>Crear cuenta</h1>
 
 <form method="post" class="stack-v" style="gap:.75rem; max-width:520px;">
-  {{ csrf_token() }}
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
   {% if invite %}
     <input type="hidden" name="token" value="{{ request.args.get('token','') }}">

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -122,3 +122,6 @@ input:focus-visible{
   .form-grid{ grid-template-columns:1fr; }
   .btn-wide{ width:100%; }
 }
+
+.inline { display: inline; }
+.toolbar form.inline { margin: 0; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -34,9 +34,12 @@
           <a class="btn btn-outline" href="{{ url_for('admin.dashboard') }}">
             {{ i.userShield() }} <span>Admin</span>
           </a>
-          <a class="btn btn-primary" href="{{ url_for('auth.logout') }}">
-            {{ i.logout() }} <span>Logout</span>
-          </a>
+          <form method="post" action="{{ url_for('auth.logout') }}" class="inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button class="btn btn-primary">
+              {{ i.logout() }} <span>Logout</span>
+            </button>
+          </form>
         {% else %}
           <a class="btn btn-primary" href="{{ url_for('auth.login') }}">
             {{ i.key() }} <span>Login</span>

--- a/tests/admin/test_admin_auth.py
+++ b/tests/admin/test_admin_auth.py
@@ -59,7 +59,7 @@ def test_admin_login_ok_and_access(app_with_admin):
     assert dashboard.status_code == 200
     assert b"Dashboard SGC" in dashboard.data
 
-    logout = client.get("/auth/logout", follow_redirects=True)
+    logout = client.post("/auth/logout", follow_redirects=True)
     assert logout.status_code == 200
     assert b"Iniciar sesi" in logout.data
 

--- a/tests/auth/test_force_change_password.py
+++ b/tests/auth/test_force_change_password.py
@@ -56,7 +56,7 @@ def test_change_password_clears_flag():
         follow_redirects=True,
     )
     assert response.status_code == 200
-    client.get("/auth/logout", follow_redirects=True)
+    client.post("/auth/logout", follow_redirects=True)
     response_login = client.post(
         "/auth/login",
         data={"username": "force", "password": "nuevo12345"},

--- a/tests/auth/test_password_flows.py
+++ b/tests/auth/test_password_flows.py
@@ -63,7 +63,7 @@ def test_change_password_ok(client):
     )
     assert r.status_code == 200
     # re-login con nueva
-    client.get("/auth/logout", follow_redirects=True)
+    client.post("/auth/logout", follow_redirects=True)
     r2 = login(client, "user", "nuevo12345")
     assert r2.status_code == 200
 

--- a/tests/auth/test_signup_approval.py
+++ b/tests/auth/test_signup_approval.py
@@ -77,7 +77,7 @@ def test_admin_can_approve_and_assign_role(client, db_session):
     assert user.category == "seguridad"
     assert user.approved_at is not None
 
-    client.get("/auth/logout", follow_redirects=True)
+    client.post("/auth/logout", follow_redirects=True)
     login_user = client.post(
         "/auth/login",
         data={"username": "juan", "password": "clave1234"},

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -50,7 +50,7 @@ def test_admin_files_listing(tmp_path, monkeypatch):
         assert "reports/report.txt" in body
         assert str(data_dir) in body
     finally:
-        client.get("/auth/logout")
+        client.post("/auth/logout")
         with app.app_context():
             db.drop_all()
             db.session.remove()


### PR DESCRIPTION
## Summary
- enforce logout to require POST with CSRF protection and clear the session
- render the logout action as an inline POST form and remove the duplicate admin logout button
- add an inline form helper, fix exposed CSRF tokens, and update tests to submit logout via POST

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15969dec48326aa320515c6817683