### PR TITLE
Add self-signup flag, pending counts, and approval tests

### DIFF
--- a/app/blueprints/admin/templates/admin/_base_admin.html
+++ b/app/blueprints/admin/templates/admin/_base_admin.html
@@ -11,7 +11,9 @@
     <a class="btn btn-outline" href="{{ admin_url('admin.users_index', 'admin.users') }}">Usuarios</a>
 
     {% if current_user.is_authenticated and current_user.role == 'admin' %}
-      <a class="btn btn-outline" href="{{ admin_url('admin.users_pending') }}">Pendientes</a>
+      <a class="btn btn-outline" href="{{ admin_url('admin.users_pending') }}">
+        Pendientes{% if pending_users_count %} ({{ pending_users_count }}){% endif %}
+      </a>
       {% if has_admin_endpoint('admin.invites_index') %}
         <a class="btn btn-outline" href="{{ admin_url('admin.invites_index') }}">Invitaciones</a>
       {% endif %}

--- a/app/blueprints/auth/templates/auth/login.html
+++ b/app/blueprints/auth/templates/auth/login.html
@@ -15,11 +15,13 @@
       <input class="form-control" type="password" name="password" required>
     </label>
     <button type="submit">Entrar</button>
-    <div class="mt-4 text-center">
-      <a href="{{ url_for('auth.register') }}" class="btn btn-lg btn-outline-primary">
-        ✨ Crear un nuevo usuario
-      </a>
-    </div>
+    {% if config.get('ALLOW_SELF_SIGNUP') %}
+      <div class="mt-4 text-center">
+        <a href="{{ url_for('auth.register') }}" class="btn btn-lg btn-outline-primary">
+          ✨ Crear un nuevo usuario
+        </a>
+      </div>
+    {% endif %}
   </form>
 </section>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -28,7 +28,7 @@
         {% if is_logged %}
           {% if current_role == "admin" %}
             <a class="btn btn-outline" href="{{ url_for('admin.users_pending') }}">
-              {{ i.bell() }} <span>Pendientes</span>
+              {{ i.bell() }} <span>Pendientes{% if pending_users_count %} ({{ pending_users_count }}){% endif %}</span>
             </a>
           {% endif %}
           <a class="btn btn-outline" href="{{ url_for('admin.dashboard') }}">

--- a/render.yaml
+++ b/render.yaml
@@ -15,6 +15,8 @@ services:
         value: INFO
       - key: FLASK_APP
         value: app:create_app
+      - key: ALLOW_SELF_SIGNUP
+        value: "false"
     buildCommand: |
       pip install --upgrade pip
       pip install -r requirements.txt

--- a/tests/auth/test_signup_approval.py
+++ b/tests/auth/test_signup_approval.py
@@ -5,7 +5,14 @@ from datetime import datetime, timezone
 from app.models import User
 
 
-def test_signup_creates_pending_user(client, db_session):
+def test_register_disabled_redirects(client):
+    response = client.get("/auth/register", follow_redirects=False)
+    assert response.status_code in (302, 303)
+    assert "/auth/login" in response.headers.get("Location", "")
+
+
+def test_signup_creates_pending_user(client, db_session, app):
+    app.config["ALLOW_SELF_SIGNUP"] = True
     response = client.post(
         "/auth/register",
         data={


### PR DESCRIPTION
## Summary
- add a default ALLOW_SELF_SIGNUP toggle and expose pending user counts to templates
- block self-service registration when disabled while keeping admin views updated with pending totals
- document the new environment variable and extend signup approval tests for the new workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d17260bc5883268c4fa08b76769260