### PR TITLE
Add route discovery tests

### DIFF
--- a/tests/test_known_candidates.py
+++ b/tests/test_known_candidates.py
@@ -1,0 +1,27 @@
+import pytest
+
+CANDIDATES = [
+    "/api/health",
+    "/api/ping",
+    "/health",
+    "/metrics",   # si usas Prometheus
+    "/",          # home
+]
+
+
+def test_any_known_candidate_responds(client, app):
+    """
+    Si la app tiene alguna ruta de salud conocida, que no truene.
+    No falla si ninguna existe: en ese caso se marca como salto.
+    """
+    # mapa para saber cuáles existen
+    existing = {r.rule for r in app.url_map.iter_rules()}
+    tested_any = False
+    for path in CANDIDATES:
+        if path not in existing:
+            continue
+        tested_any = True
+        res = client.get(path)
+        assert res.status_code < 500  # no debe tronar
+    if not tested_any:
+        pytest.skip("No se encontraron rutas candidatas de salud/ping/raíz")

--- a/tests/test_routes_discovery.py
+++ b/tests/test_routes_discovery.py
@@ -1,0 +1,46 @@
+import pytest
+
+SAFE_OK = {200, 302}        # público o redirección (por ejemplo a /login)
+SAFE_PROTECTED = {401, 403} # rutas que requieren auth (válido en CI)
+SAFE_MISSING = {404}        # algunas apps no exponen '/'
+
+# Rutas que evitamos por seguridad o porque no son GET
+BLACKLIST_EXACT = {"/static/<path:filename>", "/favicon.ico", "/logout", "/api/assets"}
+BLACKLIST_PREFIX = ("/static", "/_debug", "/docs", "/api/")  # ajusta si usas swagger/debug
+
+
+def get_get_rules(app):
+    """Devuelve reglas GET sin parámetros (para poder invocarlas en CI)."""
+    rules = []
+    for rule in app.url_map.iter_rules():
+        if "GET" not in rule.methods:
+            continue
+        if rule.arguments:           # requiere <id> etc.
+            continue
+        if rule.rule in BLACKLIST_EXACT:
+            continue
+        if any(rule.rule.startswith(p) for p in BLACKLIST_PREFIX):
+            continue
+        rules.append(rule.rule)
+    # asegura al menos la raíz
+    if "/" not in rules:
+        rules.insert(0, "/")
+    return sorted(set(rules))
+
+
+def test_route_returns_non_500(client, app):
+    """
+    Para cada ruta GET pública, aceptamos:
+      - 200/302: ok o redirección
+      - 401/403: protegida (válida en CI)
+      - 404: raíz inexistente o rutas dinámicas no montadas
+    Nunca debe ser 5xx.
+    """
+    rules = get_get_rules(app)
+    if not rules:
+        pytest.skip("No hay rutas GET sin parámetros")
+
+    for path in rules:
+        res = client.get(path)
+        assert res.status_code not in {500, 501, 502, 503, 504}
+        assert res.status_code in (SAFE_OK | SAFE_PROTECTED | SAFE_MISSING)


### PR DESCRIPTION
## Summary
- add tests that crawl GET routes and ensure they do not return 5xx responses
- add health-check candidate test covering common monitoring endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3086203708326ac2d33d0fbbfbae7