### PR TITLE
Configure Codecov flags and add endpoint smoke tests

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -9,8 +9,12 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  coverage-matrix:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        part: [api, auth, models, routes, services, utils]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,20 +24,54 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
+      - name: Install deps
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt || true
           pip install pytest pytest-cov
-          # pip install -e .   # si empaquetas tu app
 
-      - name: Run tests with coverage
+      - name: Run pytest for ${{ matrix.part }}
+        run: |
+          TARGET="app/${{ matrix.part }}"
+          # Si el folder no existe, hacemos un run mínimo para no fallar
+          if [ -d "$TARGET" ]; then
+            pytest -q --maxfail=1 --disable-warnings \
+              --cov="$TARGET" --cov-branch \
+              --cov-report=xml:coverage-${{ matrix.part }}.xml
+          else
+            echo "Folder $TARGET no existe; ejecutando tests básicos"
+            pytest -q --maxfail=1 --disable-warnings \
+              --cov=app --cov-branch \
+              --cov-report=xml:coverage-${{ matrix.part }}.xml
+          fi
+
+      - name: Upload to Codecov (${{ matrix.part }})
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage-${{ matrix.part }}.xml
+          flags: ${{ matrix.part }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  # Job extra (opcional) para ejecutar toda la suite una vez
+  coverage-all:
+    runs-on: ubuntu-latest
+    needs: coverage-matrix
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+          pip install pytest pytest-cov
+      - name: Run full suite
         run: |
           pytest -q --maxfail=1 --disable-warnings \
-            --cov=app --cov-report=term-missing \
-            --cov-report=xml:coverage.xml
-
-      - name: Upload coverage to Codecov
+            --cov=app --cov-branch --cov-report=xml:coverage.xml \
+            --cov-report=term-missing
+      - name: Upload combined
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Servidor Flask para Codex Primera configuración
 
 [![CI - Coverage](https://github.com/Mag0de0z2099/Proyecto-Codex/actions/workflows/ci-coverage.yml/badge.svg)](https://github.com/Mag0de0z2099/Proyecto-Codex/actions/workflows/ci-coverage.yml)
 [![codecov](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg)](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex)
+
+<!-- Badges por flag (Codecov Pro) -->
+[![api](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?flag=api)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex/flags/api)
+[![auth](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?flag=auth)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex/flags/auth)
+[![models](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?flag=models)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex/flags/models)
+[![routes](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?flag=routes)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex/flags/routes)
+[![services](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?flag=services)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex/flags/services)
+[![utils](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?flag=utils)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex/flags/utils)
 [![Render](https://img.shields.io/website?url=https%3A%2F%2Fproyecto-codex.onrender.com&label=Render%20Deploy&style=flat-square)](https://proyecto-codex.onrender.com)
 
 ## Checklist de despliegue seguro

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,24 +1,92 @@
+codecov:
+  require_ci_to_pass: yes
+
 coverage:
   precision: 2
   round: down
-  range: 60..95
+  range: 70..100
 
   status:
     project:
       default:
-        target: 70
-        threshold: 2
-        informational: false
+        target: 80        # ⬅️ súbelo a 90 cuando estabilice
+        threshold: 1
     patch:
       default:
-        target: 70
-        threshold: 2
-        informational: false
+        target: 75
+        threshold: 1
+
+    # Metas por flag (ver sección flags)
+    flags:
+      api:
+        target: 80
+      auth:
+        target: 80
+      models:
+        target: 80
+      routes:
+        target: 80
+      services:
+        target: 80
+      utils:
+        target: 80
 
 ignore:
   - "tests/**"
   - "migrations/**"
   - "docs/**"
-  - "**/__init__.py"
+  - "static/**"
+  - "templates/**"
   - "wsgi.py"
   - "manage.py"
+  - "render.yaml"
+  - "seed_and_scan.sh"
+  - "verify_metrics.sh"
+  - "create_pr_ui_logo.sh"
+  - "runtime.txt"
+  - "Procfile"
+
+flags:
+  api:
+    paths:
+      - app/api/
+  auth:
+    paths:
+      - app/auth/
+      - app/simple_auth/
+  models:
+    paths:
+      - app/models/
+  routes:
+    paths:
+      - app/routes/
+      - app/blueprints/
+  services:
+    paths:
+      - app/services/
+  utils:
+    paths:
+      - app/utils/
+
+component_management:
+  individual_components:
+    - name: API
+      paths:
+        - app/api/**
+    - name: Auth
+      paths:
+        - app/auth/**
+        - app/simple_auth/**
+    - name: Models
+      paths:
+        - app/models/**
+    - name: Routes
+      paths:
+        - app/routes/**
+        - app/blueprints/**
+    - name: Services
+      paths:
+        - app/services/**
+    - name: Utils
+      paths:
+        - app/utils/**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,15 +13,14 @@ if str(PROJECT_ROOT) not in sys.path:
 @pytest.fixture(scope="session")
 def app():
     os.environ.setdefault("FLASK_ENV", "testing")
+    # Usa SQLite en memoria si tu app lee DATABASE_URL
+    os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 
     try:
-        # Factory pattern
         from app import create_app
         flask_app = create_app()
     except Exception:
-        # Fallback si solo hay app global
         from app import app as flask_app
-
     return flask_app
 
 

--- a/tests/test_public_endpoints.py
+++ b/tests/test_public_endpoints.py
@@ -1,0 +1,20 @@
+import pytest
+
+# Ajusta la lista a lo que tengas disponible
+CANDIDATES = [
+    "/auth/login",
+    "/auth/signup",
+    "/logout",        # puede redirigir -> 302
+    "/api/health",
+    "/api/ping",
+    "/metrics",       # si expones Prometheus
+]
+
+
+@pytest.mark.parametrize("path", CANDIDATES)
+def test_candidates_get(client, app, path):
+    existing = {r.rule for r in app.url_map.iter_rules()}
+    if path not in existing:
+        pytest.skip(f"{path} no existe")
+    res = client.get(path)
+    assert res.status_code in (200, 302, 401, 403)


### PR DESCRIPTION
## Summary
- replace the Codecov configuration with flag-aware thresholds, component mapping, and broader ignore rules
- split the coverage workflow into a matrix by flag plus a full run uploader
- improve the Flask testing fixtures and add public endpoint smoke tests, along with README badges for each flag

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31465354c83268bd561207e01a278