### PR TITLE
Update CI coverage workflow matrix

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -9,8 +9,12 @@ permissions:
   contents: read
 
 jobs:
-  tests:
+  coverage-matrix:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        part: [api, auth, models, routes, services, utils]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,22 +24,80 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
+      - name: Install deps
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt || true
           pip install pytest pytest-cov
-          # pip install -e .   # si empaquetas tu app
+          # pip install -e .   # si empaquetas la app
 
-      - name: Run tests with coverage
+      - name: Run pytest for ${{ matrix.part }} (coverage + junit)
+        run: |
+          TARGET="app/${{ matrix.part }}"
+          if [ -d "$TARGET" ]; then
+            pytest -q --maxfail=1 --disable-warnings \
+              --cov="$TARGET" --cov-branch \
+              --cov-report=xml:coverage-${{ matrix.part }}.xml \
+              --junitxml=junit-${{ matrix.part }}.xml -o junit_family=legacy
+          else
+            echo "Folder $TARGET no existe; ejecutando suite general"
+            pytest -q --maxfail=1 --disable-warnings \
+              --cov=app --cov-branch \
+              --cov-report=xml:coverage-${{ matrix.part }}.xml \
+              --junitxml=junit-${{ matrix.part }}.xml -o junit_family=legacy
+          fi
+
+      - name: Upload test results (Test Analytics) - ${{ matrix.part }}
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: junit-${{ matrix.part }}.xml
+          flags: ${{ matrix.part }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload coverage to Codecov - ${{ matrix.part }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage-${{ matrix.part }}.xml
+          flags: ${{ matrix.part }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+  coverage-all:
+    runs-on: ubuntu-latest
+    needs: coverage-matrix
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+          pip install pytest pytest-cov
+
+      - name: Run full suite (coverage + junit)
         run: |
           pytest -q --maxfail=1 --disable-warnings \
-            --cov=app --cov-report=term-missing \
-            --cov-report=xml:coverage.xml
+            --cov=app --cov-branch \
+            --cov-report=xml:coverage.xml \
+            --junitxml=junit.xml -o junit_family=legacy
 
-      - name: Upload coverage to Codecov
+      - name: Upload test results (Test Analytics) - all
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: junit.xml
+          flags: all
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload combined coverage
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          flags: all
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
## Summary
- replace the coverage workflow with a matrix job that runs targeted pytest coverage suites per component and aggregates them
- upload both junit test results and coverage reports to Codecov for matrix entries and the full suite run

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d314e94df88326b10b1c4d857d5c11