### PR TITLE
Update coverage workflow configuration

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -16,11 +16,9 @@ jobs:
       matrix:
         part: [api, auth, models, routes, services, utils]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -30,22 +28,33 @@ jobs:
           pip install -r requirements.txt || true
           pip install pytest pytest-cov
 
-      - name: Run pytest for ${{ matrix.part }}
+      - name: Run pytest for ${{ matrix.part }} (coverage + junit)
+        # 👇 importante: opcion correcta con "="
         run: |
+          set -euxo pipefail
           TARGET="app/${{ matrix.part }}"
-          # Si el folder no existe, hacemos un run mínimo para no fallar
           if [ -d "$TARGET" ]; then
             pytest -q --maxfail=1 --disable-warnings \
               --cov="$TARGET" --cov-branch \
-              --cov-report=xml:coverage-${{ matrix.part }}.xml
+              --cov-report=xml:coverage-${{ matrix.part }}.xml \
+              --junitxml=junit-${{ matrix.part }}.xml -o junit_family=legacy
           else
-            echo "Folder $TARGET no existe; ejecutando tests básicos"
             pytest -q --maxfail=1 --disable-warnings \
               --cov=app --cov-branch \
-              --cov-report=xml:coverage-${{ matrix.part }}.xml
+              --cov-report=xml:coverage-${{ matrix.part }}.xml \
+              --junitxml=junit-${{ matrix.part }}.xml -o junit_family=legacy
           fi
 
-      - name: Upload to Codecov (${{ matrix.part }})
+      - name: Upload test results (Test Analytics) - ${{ matrix.part }}
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: junit-${{ matrix.part }}.xml
+          flags: ${{ matrix.part }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload coverage to Codecov - ${{ matrix.part }}
         uses: codecov/codecov-action@v5
         with:
           files: coverage-${{ matrix.part }}.xml
@@ -53,27 +62,42 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-  # Job extra (opcional) para ejecutar toda la suite una vez
   coverage-all:
     runs-on: ubuntu-latest
     needs: coverage-matrix
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
+
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt || true
           pip install pytest pytest-cov
-      - name: Run full suite
+
+      - name: Run full suite (coverage + junit)
         run: |
           pytest -q --maxfail=1 --disable-warnings \
-            --cov=app --cov-branch --cov-report=xml:coverage.xml \
-            --cov-report=term-missing
-      - name: Upload combined
+            --cov=app --cov-branch \
+            --cov-report=xml:coverage.xml \
+            --junitxml=junit.xml -o junit_family=legacy
+
+      - name: Upload test results (Test Analytics) - all
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: junit.xml
+          flags: all
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+
+      - name: Upload combined coverage
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          flags: all
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true


### PR DESCRIPTION
## Summary
- replace the CI coverage workflow with the new drop-in configuration
- add matrix-aware pytest runs that publish both coverage XML and JUnit results
- upload aggregated coverage and JUnit data for the full suite run

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d31bd8cb848326931cd9702861f4f9