### PR TITLE
Add pragma to metrics response

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -27,7 +27,7 @@ def metrics() -> Response:
             output = generate_latest(REGISTRY)
         response = Response(output)
         response.headers["Content-Type"] = CONTENT_TYPE_LATEST
-        return response
+        return response  # pragma: no branch
     except Exception as exc:  # pragma: no cover - defensive fallback
         return Response(
             f"# metrics unavailable: {exc}\n",


### PR DESCRIPTION
## Summary
- add a `# pragma: no branch` marker to the metrics endpoint response to avoid branch coverage noise

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d32a4e24248326b0d8d99b7c51ef46