### PR TITLE
chore(codecov): make patch check informational to unblock PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,8 +13,9 @@ coverage:
         threshold: 1
     patch:
       default:
-        target: 75
-        threshold: 1
+        target: 70
+        threshold: 2
+        informational: true   # ← no bloquea el merge
 
     # Metas por flag (ver sección flags)
     flags:


### PR DESCRIPTION
## Summary
- lower the patch coverage target to 70% with a 2% threshold
- mark the patch status check as informational so it no longer blocks merges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3569e21648326831d1a2efa456ea6