### PR TITLE
Add auth service credential verification and tests

### DIFF
--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,0 +1,122 @@
+"""Utilities for verifying user credentials used by the auth blueprint."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+
+from werkzeug.security import check_password_hash
+
+
+_DEFAULT_FAKE_USER: Mapping[str, Any] = {
+    "id": 1,
+    "email": "admin@admin.com",
+    "role": "admin",
+    "is_admin": True,
+    "is_active": True,
+}
+
+
+def _use_fake_backend(app=None) -> bool:
+    """Return True when the fake authentication backend should be used."""
+
+    if app is not None and app.config.get("FAKE_AUTH"):
+        return True
+
+    raw = os.getenv("FAKE_AUTH", "")
+    return str(raw).strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _fake_credentials_match(email: str, password: str) -> bool:
+    email = (email or "").strip().lower()
+    password = password or ""
+
+    fake_password = os.getenv("FAKE_AUTH_PASSWORD", "admin123")
+    return email == _DEFAULT_FAKE_USER["email"] and password == fake_password
+
+
+def _serialize_user(user: Any, email_fallback: str) -> dict[str, Any]:
+    """Build the dictionary representation returned by ``verify_credentials``."""
+
+    email = getattr(user, "email", None) or getattr(user, "username", None) or email_fallback
+    role = getattr(user, "role", None)
+    if not role:
+        role = "admin" if getattr(user, "is_admin", False) else "user"
+
+    return {
+        "id": getattr(user, "id", None),
+        "email": email,
+        "role": role,
+        "is_admin": bool(getattr(user, "is_admin", False)),
+        "is_active": bool(getattr(user, "is_active", True)),
+    }
+
+
+def _check_user_password(user: Any, password: str) -> bool:
+    """Evaluate if the provided password matches the stored credentials."""
+
+    checker = getattr(user, "check_password", None)
+    if callable(checker):
+        try:
+            return bool(checker(password))
+        except Exception:
+            return False
+
+    stored = getattr(user, "password", None)
+    if stored is not None:
+        return stored == password
+
+    stored_hash = getattr(user, "password_hash", None)
+    if stored_hash:
+        try:
+            return bool(check_password_hash(stored_hash, password))
+        except Exception:
+            return False
+
+    return False
+
+
+def verify_credentials(email: str, password: str, app=None) -> dict[str, Any] | None:
+    """Validate the supplied credentials and return a serializable user mapping."""
+
+    email = (email or "").strip().lower()
+    password = password or ""
+
+    if _use_fake_backend(app):
+        if _fake_credentials_match(email, password):
+            return dict(_DEFAULT_FAKE_USER)
+        return None
+
+    try:
+        from app.db import db
+        from app.models import User
+    except Exception:
+        return None
+
+    try:
+        query = db.session.query(User)
+        if hasattr(User, "email"):
+            query = query.filter_by(email=email)
+        elif hasattr(User, "username"):
+            query = query.filter_by(username=email)
+        user = query.first()
+    except Exception:
+        return None
+
+    if not user:
+        return None
+
+    if hasattr(user, "is_active") and not getattr(user, "is_active"):
+        return None
+
+    status = getattr(user, "status", None)
+    if status and str(status).lower() not in {"approved", "active", "enabled"}:
+        return None
+
+    if not _check_user_password(user, password):
+        return None
+
+    return _serialize_user(user, email)
+
+
+__all__ = ["verify_credentials"]

--- a/tests/test_auth_service_unit.py
+++ b/tests/test_auth_service_unit.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import types
+import pytest
+
+import app.services.auth_service as svc
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("FLASK_ENV", "testing")
+    os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+    try:
+        from app import create_app
+        _app = create_app()
+    except Exception:
+        from app import app as _app
+    _app.testing = True
+    return _app
+
+
+def _inject_fake_modules(monkeypatch, fake_user):
+    """
+    Inyecta módulos falsos 'app.db' y 'app.models' para que:
+      from app.db import db
+      from app.models import User
+    funcionen dentro de auth_service.verify_credentials.
+    """
+    class FakeQuery:
+        def __init__(self, user):
+            self._user = user
+        def filter(self, *args, **kwargs):
+            return self
+        def filter_by(self, **kwargs):
+            return self
+        def first(self):
+            return self._user
+
+    class FakeSession:
+        def __init__(self, user):
+            self._user = user
+        def query(self, _User):
+            return FakeQuery(self._user)
+
+    fake_db_module = types.SimpleNamespace(
+        db=types.SimpleNamespace(session=FakeSession(fake_user))
+    )
+    fake_models_module = types.SimpleNamespace(User=object)
+
+    monkeypatch.setitem(sys.modules, "app.db", fake_db_module)
+    monkeypatch.setitem(sys.modules, "app.models", fake_models_module)
+
+
+# ---------- FAKE path ----------
+def test_verify_credentials_fake_success(app):
+    app.config["FAKE_AUTH"] = True
+    user = svc.verify_credentials("admin@admin.com", "admin123", app=app)
+    assert user and user["email"] == "admin@admin.com"
+
+def test_verify_credentials_fake_invalid(app):
+    app.config["FAKE_AUTH"] = True
+    user = svc.verify_credentials("nope@site.com", "bad", app=app)
+    assert user is None
+
+
+# ---------- REAL path (simulado con módulos falsos) ----------
+def test_verify_credentials_real_success_check_password(app, monkeypatch):
+    app.config["FAKE_AUTH"] = False
+    fake_user = types.SimpleNamespace(
+        id=10, email="neo@matrix.io", role="user",
+        check_password=lambda pw: pw == "good"
+    )
+    _inject_fake_modules(monkeypatch, fake_user)
+    user = svc.verify_credentials("neo@matrix.io", "good", app=app)
+    assert user and user["email"] == "neo@matrix.io"
+
+def test_verify_credentials_real_success_plain_password(app, monkeypatch):
+    app.config["FAKE_AUTH"] = False
+    fake_user = types.SimpleNamespace(
+        id=11, email="trinity@matrix.io", role="user", password="love"
+    )
+    _inject_fake_modules(monkeypatch, fake_user)
+    user = svc.verify_credentials("trinity@matrix.io", "love", app=app)
+    assert user and user["email"] == "trinity@matrix.io"
+
+def test_verify_credentials_real_user_not_found(app, monkeypatch):
+    app.config["FAKE_AUTH"] = False
+    _inject_fake_modules(monkeypatch, fake_user=None)
+    user = svc.verify_credentials("ghost@matrix.io", "whatever", app=app)
+    assert user is None
+
+def test_verify_credentials_real_wrong_password(app, monkeypatch):
+    app.config["FAKE_AUTH"] = False
+    fake_user = types.SimpleNamespace(
+        id=12, email="smith@matrix.io", role="agent",
+        check_password=lambda pw: False,  # falla hash
+        password=None                      # y tampoco password plano
+    )
+    _inject_fake_modules(monkeypatch, fake_user)
+    user = svc.verify_credentials("smith@matrix.io", "wrong", app=app)
+    assert user is None


### PR DESCRIPTION
## Summary
- add an auth service helper that supports fake and real credential verification
- cover fake and real verification flows with isolated unit tests using monkeypatching

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36a1522dc832690db053d7ea56b92