### PR TITLE
codex/deploy-health-auth-real

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,7 @@
 # Proceso web principal (sirve la app Flask con Gunicorn)
 web: gunicorn -w 3 -t 60 wsgi:app
 
-release: flask db upgrade || true && flask seed-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD" --role admin
+release: flask db upgrade || true && flask seed-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD"
 
 # Proceso de worker (ejemplo: tareas en segundo plano)
 worker: python worker.py

--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ Servidor Flask para Codex Primera configuración
 [![utils](https://codecov.io/gh/Mag0de0z2099/Proyecto-Codex/branch/main/graph/badge.svg?flag=utils)](https://app.codecov.io/gh/Mag0de0z2099/Proyecto-Codex/flags/utils)
 [![Render](https://img.shields.io/website?url=https%3A%2F%2Fproyecto-codex.onrender.com&label=Render%20Deploy&style=flat-square)](https://proyecto-codex.onrender.com)
 
+## Deploy rápido
+
+1. **Variables obligatorias**: define `DATABASE_URL` y `SECRET_KEY` antes de desplegar.
+2. **Migración y seed**:
+
+   ```bash
+   alembic -c migrations/alembic.ini upgrade head
+   FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
+   ```
+
+3. **Smoke tests**:
+
+   ```bash
+   curl -s https://tu-app.onrender.com/healthz
+   curl -s -X POST https://tu-app.onrender.com/api/v1/auth/login \
+     -H "Content-Type: application/json" \
+     -d '{"email":"admin@admin.com","password":"admin123"}'
+   ```
+
 ## Checklist de despliegue seguro
 
 Configura las variables de entorno **antes** de desplegar en Render u otra plataforma:
@@ -49,7 +68,7 @@ FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password NUE
 ## Operación
 
 - **Gunicorn:** El Procfile y `render.yaml` inician el proyecto con `gunicorn -w 3 -t 60 wsgi:app`.
-- **Healthcheck:** `GET /healthz` devuelve `{"ok": true}` para liveness probes; `/api/v1/health` valida la conexión a la base.
+- **Healthcheck:** `GET /healthz` devuelve `{"status": "ok"}` para liveness probes; `/api/v1/health` valida la conexión a la base.
 - **Logging estructurado:** todos los logs van a `stdout` en JSON-like plano, incluyen `X-Request-ID` y respetan `LOG_LEVEL`.
 - **Rate limiting:** `/auth/forgot-password` limita solicitudes a `5/minuto` y `30/hora` por IP.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -156,6 +156,10 @@ def create_app(config_name: str | None = None) -> Flask:
     if api_v1_bp is not None:
         csrf.exempt(api_v1_bp)
 
+    auth_api_bp = blueprints.get("auth_api")
+    if auth_api_bp is not None:
+        csrf.exempt(auth_api_bp)
+
     ping_bp = blueprints.get("ping")
     if ping_bp is not None:
         limiter.exempt(ping_bp)

--- a/app/registry.py
+++ b/app/registry.py
@@ -14,6 +14,8 @@ from app.blueprints.auth import bp_auth
 from app.blueprints.ping import bp_ping
 from app.blueprints.web import bp_web
 from app.routes.assets import assets_bp
+from app.routes.auth import bp as auth_api_bp
+from app.routes.health import bp as health_bp
 from app.routes.public import public_bp
 
 
@@ -32,6 +34,8 @@ def register_blueprints(app: Flask) -> dict[str, Blueprint]:
         (version_bp, {}),
         (assets_bp, {}),
         (bp_ping, {}),
+        (health_bp, {}),
+        (auth_api_bp, {}),
     ]
 
     registry: dict[str, Blueprint] = {}

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,29 @@
+"""Authentication API endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from app.services.auth_service import verify_credentials
+
+bp = Blueprint("auth_api", __name__, url_prefix="/api/v1/auth")
+
+
+@bp.post("/login")
+def login() -> tuple[object, int]:
+    """Validate credentials and return a development token."""
+    payload = request.get_json(silent=True) or {}
+    email = payload.get("email")
+    password = payload.get("password")
+
+    if not email or not password:
+        return jsonify({"detail": "invalid credentials"}), 401
+
+    user = verify_credentials(str(email), str(password))
+    if user is None:
+        return jsonify({"detail": "invalid credentials"}), 401
+
+    if not getattr(user, "is_approved", False):
+        return jsonify({"detail": "not approved"}), 403
+
+    return jsonify({"token": "dev-token"}), 200

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,0 +1,13 @@
+"""Health check endpoint for deployment smoke tests."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+
+bp = Blueprint("health", __name__)
+
+
+@bp.get("/healthz")
+def healthz() -> tuple[object, int]:
+    """Simple readiness endpoint returning a static payload."""
+    return jsonify({"status": "ok"}), 200

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,0 +1,63 @@
+"""Authentication related services."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from app.db import db
+from app.models import User
+from app.utils.strings import normalize_email
+
+
+def verify_credentials(email: str, password: str) -> User | None:
+    """Return the user when the provided credentials are valid."""
+    normalized_email = normalize_email(email)
+    if not normalized_email or not password:
+        return None
+
+    user = User.query.filter_by(email=normalized_email).first()
+    if user is None:
+        return None
+
+    if not check_password_hash(user.password_hash, password):
+        return None
+
+    return user
+
+
+def ensure_admin_user(email: str, password: str, username: str | None = None) -> User:
+    """Create or update the administrator account."""
+    normalized_email = normalize_email(email)
+    if not normalized_email:
+        raise ValueError("Email is required")
+
+    user = User.query.filter_by(email=normalized_email).first()
+    if user is None:
+        base_username = (username or normalized_email.split("@", 1)[0] or "admin").strip() or "admin"
+        candidate = base_username
+        suffix = 1
+        while User.query.filter_by(username=candidate).first():
+            candidate = f"{base_username}{suffix}"
+            suffix += 1
+
+        user = User(
+            username=candidate,
+            email=normalized_email,
+            role="admin",
+            is_admin=True,
+        )
+        db.session.add(user)
+
+    user.password_hash = generate_password_hash(password)
+    user.is_active = True
+    user.is_approved = True
+    user.approved_at = datetime.now(timezone.utc)
+    user.status = "approved"
+    user.role = "admin"
+    user.is_admin = True
+    user.force_change_password = False
+
+    db.session.commit()
+    return user

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,7 @@
 import click
 from flask_migrate import upgrade
+
+from app.services.auth_service import ensure_admin_user
 from wsgi import app  # importa tu app ya inicializada con Migrate
 
 
@@ -14,6 +16,26 @@ def db_upgrade():
     with app.app_context():
         upgrade()
         click.echo("DB upgraded successfully")
+
+
+@cli.command("seed-admin")
+@click.option("--email", required=True, help="Correo del administrador")
+@click.option(
+    "--password",
+    required=True,
+    help="Contraseña para el administrador",
+)
+@click.option(
+    "--username",
+    required=False,
+    help="Username opcional (si no se indica se deriva del email)",
+)
+def seed_admin(email: str, password: str, username: str | None = None):
+    """Crea o actualiza el usuario administrador con las credenciales dadas."""
+
+    with app.app_context():
+        user = ensure_admin_user(email=email, password=password, username=username)
+        click.echo(f"Seeded admin: {user.email} ({user.username})")
 
 
 if __name__ == "__main__":

--- a/migrations/versions/20251008_auth_flags.py
+++ b/migrations/versions/20251008_auth_flags.py
@@ -1,0 +1,78 @@
+"""add approval flags to users"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+revision = "20251008_auth_flags"
+down_revision = "bc7a3436789d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    missing_email_rows = conn.execute(text("SELECT id FROM users WHERE email IS NULL")).fetchall()
+    for row in missing_email_rows:
+        placeholder = f"user{row.id}@example.invalid"
+        conn.execute(
+            text("UPDATE users SET email = :email WHERE id = :id"),
+            {"email": placeholder, "id": row.id},
+        )
+
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.alter_column(
+            "email",
+            existing_type=sa.String(length=254),
+            nullable=False,
+        )
+        batch.add_column(
+            sa.Column(
+                "is_approved",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            )
+        )
+
+    approved_condition = text(
+        "UPDATE users\n"
+        "   SET is_approved = 1\n"
+        " WHERE lower(COALESCE(status, '')) = 'approved' OR is_admin = 1"
+    )
+    if dialect == "postgresql":
+        approved_condition = text(
+            "UPDATE users\n"
+            "   SET is_approved = TRUE\n"
+            " WHERE lower(COALESCE(status, '')) = 'approved' OR is_admin = TRUE"
+        )
+
+    conn.execute(approved_condition)
+
+    timestamp_sql = "CURRENT_TIMESTAMP"
+    if dialect == "postgresql":
+        timestamp_sql = "TIMEZONE('utc', NOW())"
+
+    conn.execute(
+        text(
+            "UPDATE users\n"
+            f"   SET approved_at = {timestamp_sql}\n"
+            " WHERE is_approved = :true AND approved_at IS NULL"
+        ),
+        {"true": True if dialect == "postgresql" else 1},
+    )
+
+    if dialect != "sqlite":
+        op.alter_column("users", "is_approved", server_default=None)
+
+
+def downgrade():
+    with op.batch_alter_table("users", schema=None) as batch:
+        batch.drop_column("is_approved")
+        batch.alter_column(
+            "email",
+            existing_type=sa.String(length=254),
+            nullable=True,
+        )

--- a/render.yaml
+++ b/render.yaml
@@ -2,26 +2,16 @@ services:
   - type: web
     name: proyecto-codex
     env: python
-    envVars:
-      - key: SECRET_KEY
-        sync: false
-      - key: DATABASE_URL
-        sync: false
-      - key: FLASK_ENV
-        value: production
-      - key: FLASK_DEBUG
-        value: "0"
-      - key: LOG_LEVEL
-        value: INFO
-      - key: FLASK_APP
-        value: app:create_app
-      - key: ALLOW_SELF_SIGNUP
-        value: "false"
-    buildCommand: |
-      pip install --upgrade pip
-      pip install -r requirements.txt
-    preDeploy:
-      - flask db upgrade || true
-      - flask seed-admin --email $ADMIN_EMAIL --password $ADMIN_PASSWORD --role admin
+    buildCommand: pip install -r requirements.txt
+    preDeployCommand: |
+      alembic -c migrations/alembic.ini upgrade head && \
+      FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
     startCommand: gunicorn -w 3 wsgi:app
     healthCheckPath: /healthz
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: codex-db
+          property: connectionString
+      - key: SECRET_KEY
+        generateValue: true

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from app.db import db
+from app.models import User
+
+
+@pytest.fixture()
+def app_ctx(app):
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        yield
+        db.session.remove()
+        db.drop_all()
+
+
+def _create_user(email: str, password: str, approved: bool) -> User:
+    hashed = generate_password_hash(password)
+    user = User(
+        username=email.split("@", 1)[0],
+        email=email,
+        password_hash=hashed,
+        is_active=True,
+        is_admin=False,
+        role="viewer",
+        status="approved" if approved else "pending",
+        approved_at=datetime.now(timezone.utc) if approved else None,
+        is_approved=approved,
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def test_login_ok_returns_token(client, app_ctx):
+    _create_user("a@example.com", "secret", approved=True)
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "a@example.com", "password": "secret"},
+    )
+    payload = response.get_json()
+    assert response.status_code == 200
+    assert payload == {"token": "dev-token"}
+
+
+def test_login_not_approved_returns_403(client, app_ctx):
+    _create_user("b@example.com", "secret", approved=False)
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "b@example.com", "password": "secret"},
+    )
+    assert response.status_code == 403
+    assert response.get_json()["detail"] == "not approved"
+
+
+def test_login_bad_credentials_returns_401(client, app_ctx):
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "missing@example.com", "password": "secret"},
+    )
+    assert response.status_code == 401
+    assert response.get_json()["detail"] == "invalid credentials"

--- a/tests/smoke/test_healthz.py
+++ b/tests/smoke/test_healthz.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def test_healthz(client):
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.is_json
+    assert response.get_json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- Add health check blueprint registered globally for Render smoke checks.
- Implement real authentication service, API login endpoint, and admin seeding helpers using hashed passwords with approval checks.
- Extend user model/migrations for approval flags, document quick deploy steps, and add coverage tests for health/login plus Render config updates.

## Testing
- pytest -q

Descripción para Codex:

Tareas:
1) Ruta de salud:
   - Crear blueprint app/routes/health.py con GET /healthz → {"status": "ok"} 200.
   - Registrar el blueprint en create_app.

2) Auth real:
   - Modelo User debe tener: id, email (único), password_hash, is_active (bool), is_approved (bool), approved_at (DateTime, nullable).
   - Implementar app/services/auth_service.py con:
       verify_credentials(email, password) → User|None (valida hash).
   - Ruta /api/v1/auth/login:
       * 200 si credenciales válidas y user.is_approved==True (retorna {"token":"dev-token"}).
       * 403 si válidas pero !is_approved.
       * 401 si credenciales inválidas.
   - Usar werkzeug.security (generate_password_hash, check_password_hash).

3) Seeds/migración:
   - Alembic migration que asegure columnas is_active, is_approved, approved_at.
   - manage.py seed-admin crea/actualiza admin@admin.com con password 'admin123',
     is_active=True, is_approved=True, approved_at=utcnow.

4) Tests:
   - tests/smoke/test_healthz.py → GET /healthz == 200 {"status":"ok"}.
   - tests/auth/test_login.py:
       * test_login_ok_returns_token (user aprobado).
       * test_login_not_approved_returns_403.
       * test_login_bad_credentials_returns_401.

5) Config/Deploy:
   - Verificar render.yaml:
       preDeployCommand: |
         alembic -c migrations/alembic.ini upgrade head && \
         FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
   - README: sección rápida de Deploy (variables env requeridas: DATABASE_URL, SECRET_KEY).

Asegura pasar pytest -q y mantener estilo actual del repo.

2) Parches guía (si Codex necesita referencia)
a) app/routes/health.py
from flask import Blueprint, jsonify

bp = Blueprint("health", __name__)

@bp.get("/healthz")
def healthz():
    return jsonify({"status": "ok"}), 200


Regístralo en app/__init__.py:

def create_app():
    app = Flask(__name__)
    # ... config & db.init ...
    from .routes.health import bp as health_bp
    app.register_blueprint(health_bp)
    return app

b) app/models/user.py (campos clave)
from datetime import datetime
from .extensions import db

class User(db.Model):
    id = db.Column(db.Integer, primary_key=True)
    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
    password_hash = db.Column(db.String(255), nullable=False)
    is_active = db.Column(db.Boolean, default=True, nullable=False)
    is_approved = db.Column(db.Boolean, default=False, nullable=False)
    approved_at = db.Column(db.DateTime, nullable=True)

    def approve(self):
        self.is_approved = True
        self.approved_at = datetime.utcnow()

c) app/services/auth_service.py
from werkzeug.security import check_password_hash
from app.models.user import User
from app.extensions import db

def verify_credentials(email: str, password: str):
    user = User.query.filter_by(email=email).first()
    if not user:
        return None
    if not check_password_hash(user.password_hash, password):
        return None
    return user

d) app/routes/auth.py (login)
from flask import Blueprint, request, jsonify
from app.services.auth_service import verify_credentials

bp = Blueprint("auth", __name__, url_prefix="/api/v1/auth")

@bp.post("/login")
def login():
    data = request.get_json(force=True, silent=True) or {}
    email = data.get("email")
    password = data.get("password")
    user = verify_credentials(email, password)
    if not user:
        return jsonify({"detail": "invalid credentials"}), 401
    if not user.is_approved:
        return jsonify({"detail": "not approved"}), 403
    return jsonify({"token": "dev-token"}), 200


(asegúrate de registrar el blueprint en create_app).

e) manage.py (seed-admin)
import click
from datetime import datetime
from werkzeug.security import generate_password_hash
from app import create_app
from app.extensions import db
from app.models.user import User

app = create_app()

@app.cli.command("seed-admin")
@click.option("--email", required=True)
@click.option("--password", required=True)
def seed_admin(email, password):
    with app.app_context():
        u = User.query.filter_by(email=email).first()
        if not u:
            u = User(email=email, password_hash=generate_password_hash(password))
            db.session.add(u)
        else:
            u.password_hash = generate_password_hash(password)
        u.is_active = True
        u.is_approved = True
        u.approved_at = datetime.utcnow()
        db.session.commit()
        click.echo(f"Seeded admin: {email}")

f) Tests (resumen)

tests/smoke/test_healthz.py

def test_healthz(client):
    r = client.get("/healthz")
    assert r.status_code == 200
    assert r.get_json()["status"] == "ok"


tests/auth/test_login.py

from werkzeug.security import generate_password_hash
from app.models.user import User
from app.extensions import db
from datetime import datetime

def _make_user(email, pwd, approved):
    u = User(email=email, password_hash=generate_password_hash(pwd), is_active=True,
             is_approved=approved, approved_at=(datetime.utcnow() if approved else None))
    db.session.add(u); db.session.commit(); return u

def test_login_ok_returns_token(client, app_ctx):
    _make_user("a@a.com","x",approved=True)
    r = client.post("/api/v1/auth/login", json={"email":"a@a.com","password":"x"})
    assert r.status_code == 200 and "token" in r.get_json()

def test_login_not_approved_returns_403(client, app_ctx):
    _make_user("b@b.com","y",approved=False)
    r = client.post("/api/v1/auth/login", json={"email":"b@b.com","password":"y"})
    assert r.status_code == 403

def test_login_bad_credentials_returns_401(client, app_ctx):
    r = client.post("/api/v1/auth/login", json={"email":"none@x.com","password":"z"})
    assert r.status_code == 401

g) render.yaml (verifica preDeploy)
services:
  - type: web
    env: python
    buildCommand: pip install -r requirements.txt
    startCommand: gunicorn 'app:create_app()'
    preDeployCommand: >
      alembic -c migrations/alembic.ini upgrade head &&
      FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
    envVars:
      - key: DATABASE_URL
        fromDatabase:
          name: your-db
          property: connectionString
      - key: SECRET_KEY
        generateValue: true

3) Comandos de verificación (local)
# Migrar y seed
alembic -c migrations/alembic.ini upgrade head
FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123

# Tests
pytest -q

# Probar endpoints (si corres flask/gunicorn en local)
curl -s http://localhost:5000/healthz
curl -s -X POST http://localhost:5000/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"admin@admin.com","password":"admin123"}'

4) Entregables del sprint

✅ CI verde con smoke + auth.

✅ /healthz visible en Render.

✅ Login real (admin aprobado por seed).

✅ README con ejemplo de curl.


------
https://chatgpt.com/codex/tasks/task_e_68d48f3ccf1c83269218782eab4925ae