### PR TITLE
Add refresh token support and rate limit login attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,4 +155,13 @@ curl -s "$BASE/api/v1/auth/me" -H "Authorization: Bearer $TOKEN"
 
 # Listar pendientes (requiere admin)
 curl -s "$BASE/api/v1/users?status=pending" -H "Authorization: Bearer $TOKEN"
+
+### Refresh token
+# Pide nuevos tokens usando el refresh recibido en /auth/login
+REFRESH="<Pega_aquí_el_refresh_token>"
+curl -s -X POST "$BASE/api/v1/auth/refresh" -H "Content-Type: application/json" \
+  -d "{\"refresh_token\":\"$REFRESH\"}"
+
+### Rate-limit de login
+- Límite: **5 intentos por minuto por IP** (HTTP 429 al exceder).
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,9 +11,8 @@ from flask import Flask
 from pytz import timezone
 from .cli_sync import register_sync_cli
 from .config import load_config
-from .db import db
 from .errors import register_error_handlers
-from .extensions import csrf, init_auth_extensions, limiter
+from .extensions import csrf, db, init_auth_extensions, limiter
 from .metrics import cleanup_multiprocess_directory
 from .utils.scan_lock import get_scan_lock
 from .cli import register_cli
@@ -114,10 +113,11 @@ def create_app(config_name: str | None = None) -> Flask:
     ):
         cleanup_multiprocess_directory()
 
-    # DB
+    # DB y extensiones compartidas
     db.init_app(app)
     init_migrations(app, db)
     init_auth_extensions(app)
+    limiter.init_app(app)
 
     set_security_headers(app)
 

--- a/app/db.py
+++ b/app/db.py
@@ -1,4 +1,3 @@
 from __future__ import annotations
-from flask_sqlalchemy import SQLAlchemy
 
-db = SQLAlchemy()
+from .extensions import db

--- a/app/errors.py
+++ b/app/errors.py
@@ -4,6 +4,7 @@ import logging
 import uuid
 
 from flask import g, jsonify, request
+from flask_limiter.errors import RateLimitExceeded
 
 
 def _json_error(status: int, message: str | None = None):
@@ -56,6 +57,10 @@ def register_error_handlers(app):
     @app.errorhandler(405)
     def _405(e):
         return _json_error(405, getattr(e, "description", "Method Not Allowed"))
+
+    @app.errorhandler(RateLimitExceeded)
+    def _429(e):
+        return _json_error(429, getattr(e, "description", "Too Many Requests"))
 
     @app.errorhandler(Exception)
     def _500(e):

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,4 +1,4 @@
-"""Extensiones compartidas para autenticación."""
+"""Extensiones compartidas para autenticación y utilidades globales."""
 
 from __future__ import annotations
 
@@ -6,14 +6,18 @@ from flask_bcrypt import Bcrypt
 from flask_login import LoginManager
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect
-
-from .db import db
 
 bcrypt = Bcrypt()
 login_manager = LoginManager()
 login_manager.login_view = "auth.login"
 csrf = CSRFProtect()
+
+# Base de datos
+db = SQLAlchemy()
+
+# Rate limiting (lazy init, se inicializa en create_app)
 limiter = Limiter(key_func=get_remote_address, headers_enabled=True, default_limits=[])
 
 
@@ -22,4 +26,3 @@ def init_auth_extensions(app):
     bcrypt.init_app(app)
     login_manager.init_app(app)
     csrf.init_app(app)
-    limiter.init_app(app)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
-from flask import Blueprint, jsonify, request, g
+from flask import Blueprint, g, jsonify, request, session
 
 from app.services.auth_service import verify_credentials
-from app.security.jwt import encode_jwt
+from app.security.jwt import decode_jwt, encode_jwt, encode_refresh_jwt
 from app.security.guards import requires_auth
+from app.extensions import limiter
 
 bp = Blueprint("auth_api", __name__, url_prefix="/api/v1/auth")
 
 
 @bp.post("/login")
+@limiter.limit("5 per minute")
 def login() -> tuple[object, int]:
     """Validate credentials and return a JWT token."""
     payload = request.get_json(force=True, silent=True) or {}
@@ -25,8 +27,20 @@ def login() -> tuple[object, int]:
     if not getattr(user, "is_approved", False):
         return jsonify({"detail": "not approved"}), 403
 
-    token = encode_jwt({"sub": user.id, "email": user.email, "role": getattr(user, "role", "user")}, ttl_seconds=3600)
-    return jsonify({"access_token": token, "token_type": "bearer"}), 200
+    role = getattr(user, "role", "user")
+    access_token = encode_jwt({"sub": user.id, "email": user.email, "role": role}, ttl_seconds=15 * 60)
+    refresh_token = encode_refresh_jwt({"sub": user.id, "email": user.email, "role": role})
+    session["token"] = access_token
+    return (
+        jsonify(
+            {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "token_type": "bearer",
+            }
+        ),
+        200,
+    )
 
 
 @bp.get("/me")
@@ -34,3 +48,44 @@ def login() -> tuple[object, int]:
 def me() -> tuple[object, int]:
     """Return current user basic information."""
     return jsonify({"email": g.current_user_email, "role": g.current_user_role}), 200
+
+
+@bp.post("/refresh")
+def refresh() -> tuple[object, int]:
+    """Issue a new access/refresh pair using a refresh token."""
+
+    auth_header = request.headers.get("Authorization", "")
+    body = request.get_json(silent=True) or {}
+
+    token: str | None = None
+    if auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1].strip()
+    if not token:
+        token = body.get("refresh_token")
+
+    if not token:
+        return jsonify({"detail": "refresh token required"}), 401
+
+    data = decode_jwt(token) or {}
+    if data.get("typ") != "refresh":
+        return jsonify({"detail": "invalid refresh"}), 401
+
+    role = data.get("role", "user")
+    access_token = encode_jwt(
+        {"sub": data.get("sub"), "email": data.get("email"), "role": role},
+        ttl_seconds=15 * 60,
+    )
+    refresh_token = encode_refresh_jwt(
+        {"sub": data.get("sub"), "email": data.get("email"), "role": role}
+    )
+    session["token"] = access_token
+    return (
+        jsonify(
+            {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "token_type": "bearer",
+            }
+        ),
+        200,
+    )

--- a/app/security/jwt.py
+++ b/app/security/jwt.py
@@ -1,4 +1,5 @@
 import time
+
 import jwt
 from flask import current_app
 
@@ -10,7 +11,7 @@ def _secret() -> str:
     return current_app.config.get("SECRET_KEY", "dev-secret")
 
 
-def encode_jwt(payload: dict, ttl_seconds: int = 3600) -> str:
+def encode_jwt(payload: dict, ttl_seconds: int = 3600, typ: str = "access") -> str:
     now = int(time.time())
     normalized = dict(payload)
     if "sub" in normalized and normalized["sub"] is not None:
@@ -18,6 +19,7 @@ def encode_jwt(payload: dict, ttl_seconds: int = 3600) -> str:
     to_encode = {
         "iat": now,
         "exp": now + ttl_seconds,
+        "typ": typ,
         **normalized,
     }
     return jwt.encode(to_encode, _secret(), algorithm=ALGO)
@@ -28,3 +30,7 @@ def decode_jwt(token: str) -> dict | None:
         return jwt.decode(token, _secret(), algorithms=[ALGO])
     except Exception:
         return None
+
+
+def encode_refresh_jwt(payload: dict, ttl_seconds: int = 7 * 24 * 3600) -> str:
+    return encode_jwt(payload, ttl_seconds=ttl_seconds, typ="refresh")

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -31,6 +31,7 @@ def test_login_ok_returns_token(client, app_ctx):
     payload = response.get_json()
     assert response.status_code == 200
     assert "access_token" in payload and payload["access_token"]
+    assert "refresh_token" in payload and payload["refresh_token"]
     assert payload.get("token_type") == "bearer"
 
 

--- a/tests/auth/test_refresh_and_ratelimit.py
+++ b/tests/auth/test_refresh_and_ratelimit.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from werkzeug.security import generate_password_hash
+
+from app.extensions import db
+from app.models import User
+
+
+def _create_user(email: str, password: str, role: str = "admin") -> User:
+    user = User(
+        email=email,
+        username=email.split("@", 1)[0],
+        password_hash=generate_password_hash(password),
+        is_active=True,
+        is_approved=True,
+    )
+    if hasattr(user, "role"):
+        user.role = role
+    if hasattr(user, "status"):
+        user.status = "approved"
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _login(client, email: str, password: str):
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+    )
+    payload = response.get_json() or {}
+    return response.status_code, payload.get("access_token"), payload.get("refresh_token")
+
+
+def test_refresh_flow(client, app_ctx):
+    _create_user("refresh@example.com", "secret")
+    status, access_token, refresh_token = _login(client, "refresh@example.com", "secret")
+
+    assert status == 200
+    assert access_token
+    assert refresh_token
+
+    refresh_response = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    new_payload = refresh_response.get_json() or {}
+
+    assert refresh_response.status_code == 200
+    assert new_payload.get("access_token")
+    assert new_payload.get("refresh_token")
+
+
+def test_rate_limit_login(client, app_ctx):
+    _create_user("ratelimit@example.com", "secret")
+
+    for _ in range(5):
+        client.post(
+            "/api/v1/auth/login",
+            json={"email": "ratelimit@example.com", "password": "wrong"},
+        )
+
+    sixth_response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "ratelimit@example.com", "password": "wrong"},
+    )
+
+    assert sixth_response.status_code == 429

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from app.db import db
+from app.extensions import limiter
 
 
 @pytest.fixture(scope="session")
@@ -41,3 +42,4 @@ def app_ctx(app):
         finally:
             db.session.remove()
             db.drop_all()
+            limiter.reset()


### PR DESCRIPTION
## Summary
- expose the SQLAlchemy and Flask-Limiter extensions from `app.extensions` and initialize the limiter in the app factory with a custom 429 handler
- issue short-lived access tokens plus refresh tokens during login and add an `/auth/refresh` endpoint protected by JWT type checks
- update authentication documentation and tests, including coverage for the refresh flow and login rate limiting behavior

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4c171522c832697643668f27f0924