### PR TITLE
Add user listing search and pagination support

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ curl -s "$BASE/api/v1/users?status=pending" -H "Authorization: Bearer $TOKEN"
 
 ### Refresh token
 # Pide nuevos tokens usando el refresh recibido en /auth/login
+
+### Listado con filtros, búsqueda y paginación
+`GET /api/v1/users` acepta estos parámetros opcionales:
+
+- `status`: `pending` o `approved`.
+- `q`: fragmento del correo a buscar (no sensible a mayúsculas).
+- `page`: número de página (por defecto 1).
+- `per_page`: cantidad por página (por defecto 10, máximo 100).
 REFRESH="<Pega_aquí_el_refresh_token>"
 curl -s -X POST "$BASE/api/v1/auth/refresh" -H "Content-Type: application/json" \
   -d "{\"refresh_token\":\"$REFRESH\"}"

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -1,45 +1,80 @@
-from flask import Blueprint, jsonify, current_app
+from __future__ import annotations
+
 import os
+from typing import Any
+
+from flask import Blueprint, current_app, jsonify, request
 
 from app.security.guards import requires_auth, requires_role
+from app.services.user_service import approve_user as service_approve_user
+from app.services.user_service import list_users as service_list_users
 
 bp = Blueprint("users_v1", __name__, url_prefix="/api/v1")
+
+
+def _parse_positive_int(raw: str | None, default: int, *, upper: int | None = None) -> int:
+    try:
+        value = int(raw) if raw is not None else default
+    except (TypeError, ValueError):
+        return default
+    if value <= 0:
+        value = default
+    if upper is not None and value > upper:
+        value = upper
+    return value
+
+
+def _serialize_user(user: Any) -> dict[str, Any]:
+    return {
+        "id": getattr(user, "id", None),
+        "email": getattr(user, "email", None),
+        "username": getattr(user, "username", None),
+        "is_approved": bool(getattr(user, "is_approved", False)),
+        "status": getattr(user, "status", None),
+    }
 
 
 @bp.get("/users")
 @requires_auth
 @requires_role("admin")
 def list_users():
-    """
-    Devuelve lista de usuarios.
-    - En TEST/CI puedes forzar un backend 'fake' con:
-        current_app.config["FAKE_USERS"] = True   (en tests)
-      o poniendo la env var FAKE_USERS=1
-    - Si no hay DB o falla el query, devuelve lista vacía (200) para evitar 500 en CI.
-    """
-    # Backend fake para CI/tests sin DB:
+    """Return users supporting filters, search and pagination."""
+
+    status = request.args.get("status")
+    search = request.args.get("q")
+    page = _parse_positive_int(request.args.get("page"), 1)
+    per_page = _parse_positive_int(request.args.get("per_page"), 10, upper=100)
+
     if current_app.config.get("FAKE_USERS") or os.getenv("FAKE_USERS"):
-        data = [
-            {"id": 1, "email": "alice@example.com"},
-            {"id": 2, "email": "bob@example.com"},
+        fake_items = [
+            {"id": 1, "email": "alice@example.com", "is_approved": True},
+            {"id": 2, "email": "bob@example.com", "is_approved": True},
         ]
-        return jsonify(users=data), 200
-
-    # Camino DB real (si existe)
-    try:
-        from app.db import db
-        from app.models import User
-    except Exception:
-        # Si no hay DB/modelo, no reventamos
-        return jsonify(users=[]), 200
+        meta = {
+            "page": page,
+            "per_page": per_page,
+            "pages": 1,
+            "total": len(fake_items),
+        }
+        return jsonify(items=fake_items, meta=meta, users=fake_items), 200
 
     try:
-        users = db.session.query(User).limit(50).all()
-        data = [{"id": getattr(u, "id", None), "email": getattr(u, "email", None)} for u in users]
-        return jsonify(users=data), 200
+        rows, meta = service_list_users(
+            status=status,
+            search=search,
+            page=page,
+            per_page=per_page,
+        )
     except Exception:
-        # Evitar 500 en CI si hay dependencias externas
-        return jsonify(users=[]), 200
+        empty_meta = {"page": page, "per_page": per_page, "pages": 1, "total": 0}
+        return jsonify(items=[], meta=empty_meta, users=[]), 200
+
+    data = [_serialize_user(row) for row in rows]
+    meta.setdefault("page", page)
+    meta.setdefault("per_page", per_page)
+    meta.setdefault("pages", 1)
+    meta.setdefault("total", len(data))
+    return jsonify(items=data, meta=meta, users=data), 200
 
 
 @bp.patch("/users/<int:user_id>/approve")
@@ -47,24 +82,12 @@ def list_users():
 @requires_role("admin")
 def approve_user(user_id: int):
     try:
-        from app.db import db
-        from app.models import User
+        user = service_approve_user(user_id)
     except Exception:
-        return jsonify({"detail": "service unavailable"}), 503
+        return jsonify({"detail": "error updating user"}), 500
 
-    user = User.query.get(user_id)
     if user is None:
         return jsonify({"detail": "not found"}), 404
-
-    try:
-        if hasattr(user, "approve"):
-            user.approve()
-        else:
-            setattr(user, "is_approved", True)
-        db.session.commit()
-    except Exception:
-        db.session.rollback()
-        return jsonify({"detail": "error updating user"}), 500
 
     if hasattr(user, "to_dict"):
         return jsonify(user=user.to_dict()), 200

--- a/app/blueprints/admin/templates/admin/users.html
+++ b/app/blueprints/admin/templates/admin/users.html
@@ -8,6 +8,32 @@
     <a href="{{ url_for('admin.admin_new_user') }}" class="btn btn-primary btn-wide">➕ Crear usuario</a>
   </div>
 
+  <form method="get" class="filters stack-h gap-2">
+    <div>
+      <label for="q">Buscar</label>
+      <input id="q" type="search" name="q" value="{{ q or '' }}" placeholder="Correo o usuario">
+    </div>
+    <div>
+      <label for="status">Estado</label>
+      <select id="status" name="status">
+        <option value="" {{ 'selected' if not status else '' }}>Todos</option>
+        <option value="pending" {{ 'selected' if status == 'pending' else '' }}>Pendientes</option>
+        <option value="approved" {{ 'selected' if status == 'approved' else '' }}>Aprobados</option>
+      </select>
+    </div>
+    <div>
+      <label for="per_page">Por página</label>
+      <select id="per_page" name="per_page">
+        {% for size in (5, 10, 20, 50, 100) %}
+          <option value="{{ size }}" {{ 'selected' if meta.per_page == size else '' }}>{{ size }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="align-end">
+      <button type="submit" class="btn btn-outline">Aplicar</button>
+    </div>
+  </form>
+
   <div class="table-grid header-8">
     <div class="th">Usuario</div>
     <div class="th">Rol</div>
@@ -88,6 +114,20 @@
         <div>—</div>
       {% endif %}
     {% endfor %}
+  </div>
+
+  <div class="stack-h space-between align-center mt-3">
+    <div>
+      Total: <strong>{{ meta.total }}</strong> · Página {{ meta.page }} de {{ meta.pages }}
+    </div>
+    <div class="stack-h gap-2">
+      {% if meta.page > 1 %}
+        <a class="btn btn-outline" href="{{ url_for('admin.users', status=status or None, q=q or None, per_page=meta.per_page, page=meta.page - 1) }}">◀ Anterior</a>
+      {% endif %}
+      {% if meta.page < meta.pages %}
+        <a class="btn btn-outline" href="{{ url_for('admin.users', status=status or None, q=q or None, per_page=meta.per_page, page=meta.page + 1) }}">Siguiente ▶</a>
+      {% endif %}
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+
+from app.extensions import db
+from app.models import User
+
+
+def list_users(
+    status: str | None = None,
+    search: str | None = None,
+    page: int | None = None,
+    per_page: int | None = None,
+) -> tuple[list[User], dict[str, int]]:
+    """Return users filtered by status/search with optional pagination."""
+
+    query = User.query
+
+    if status == "pending":
+        query = query.filter(User.is_approved.is_(False))
+    elif status == "approved":
+        query = query.filter(User.is_approved.is_(True))
+
+    if search:
+        term = f"%{search.strip().lower()}%"
+        query = query.filter(sa.func.lower(User.email).like(term))
+
+    query = query.order_by(User.id.asc())
+
+    if page is not None and per_page is not None:
+        page = max(int(page or 1), 1)
+        per_page = max(int(per_page or 1), 1)
+        try:
+            pagination = db.paginate(
+                query,
+                page=page,
+                per_page=per_page,
+                error_out=False,
+            )
+            items = list(pagination.items)
+            meta = {
+                "page": pagination.page,
+                "per_page": pagination.per_page,
+                "pages": pagination.pages,
+                "total": pagination.total,
+            }
+            return items, meta
+        except Exception:
+            total = query.count()
+            pages = (total + per_page - 1) // per_page if total else 0
+            if pages and page > pages:
+                page = pages
+            elif not pages:
+                page = 1
+            offset = max((page - 1) * per_page, 0)
+            items = query.offset(offset).limit(per_page).all()
+            meta = {
+                "page": page,
+                "per_page": per_page,
+                "pages": pages or 1,
+                "total": total,
+            }
+            return list(items), meta
+
+    items = query.all()
+    total = len(items)
+    meta = {"page": 1, "per_page": total, "pages": 1, "total": total}
+    return list(items), meta
+
+
+def approve_user(user_id: int) -> User | None:
+    """Approve a user by ID."""
+
+    user = db.session.get(User, user_id)
+    if user is None:
+        return None
+
+    if hasattr(user, "approve"):
+        user.approve()
+    else:
+        user.is_approved = True
+        if hasattr(user, "status"):
+            try:
+                user.status = "approved"
+            except Exception:
+                pass
+        if hasattr(user, "approved_at") and getattr(user, "approved_at", None) is None:
+            user.approved_at = datetime.now(timezone.utc)
+
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    return user

--- a/tests/test_api_v1_users.py
+++ b/tests/test_api_v1_users.py
@@ -59,9 +59,11 @@ def test_users_fake_backend_returns_list(client, app, monkeypatch, app_ctx):
     res = client.get("/api/v1/users", headers=headers)
     assert res.status_code == 200 and res.is_json
     data = res.get_json()
-    assert isinstance(data.get("users"), list)
-    assert len(data["users"]) >= 2
-    assert "email" in data["users"][0]
+    assert isinstance(data.get("items"), list)
+    assert len(data["items"]) >= 2
+    assert "email" in data["items"][0]
+    assert "meta" in data
+    assert data["meta"]["total"] >= 2
 
 
 def test_users_db_path_graceful(client, app, monkeypatch, app_ctx):
@@ -72,5 +74,6 @@ def test_users_db_path_graceful(client, app, monkeypatch, app_ctx):
     res = client.get("/api/v1/users", headers=headers)
     assert res.status_code == 200 and res.is_json
     data = res.get_json()
-    assert "users" in data
-    assert isinstance(data["users"], list)
+    assert "items" in data
+    assert isinstance(data["items"], list)
+    assert "meta" in data

--- a/tests/users/test_users_pagination_search.py
+++ b/tests/users/test_users_pagination_search.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from werkzeug.security import generate_password_hash
+
+from app.extensions import db
+from app.models import User
+
+
+def _mk(count: int = 15, approved: bool = True) -> list[User]:
+    rows: list[User] = []
+    for i in range(count):
+        user = User(
+            email=f"user{i}@example.com",
+            username=f"user{i}",
+            password_hash=generate_password_hash("secret"),
+            is_active=True,
+            is_approved=approved if i % 2 == 0 else not approved,
+        )
+        try:
+            user.role = "user"
+        except Exception:
+            pass
+        try:
+            user.status = "approved" if user.is_approved else "pending"
+        except Exception:
+            pass
+        db.session.add(user)
+        rows.append(user)
+    db.session.commit()
+    return rows
+
+
+def _login_admin(client) -> str:
+    admin = User.query.filter_by(email="admin@test.com").one_or_none()
+    if admin is None:
+        admin = User(
+            email="admin@test.com",
+            username="admin",
+            password_hash=generate_password_hash("secret"),
+            is_active=True,
+            is_approved=True,
+        )
+        db.session.add(admin)
+    else:
+        admin.password_hash = generate_password_hash("secret")
+    try:
+        admin.role = "admin"
+    except Exception:
+        pass
+    try:
+        admin.status = "approved"
+    except Exception:
+        pass
+    db.session.commit()
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "admin@test.com", "password": "secret"},
+    )
+    token = (response.get_json() or {}).get("access_token")
+    assert token, "login should provide a token"
+    return token
+
+
+def test_users_api_pagination_and_search(client, app_ctx):
+    _mk(17)
+    token = _login_admin(client)
+
+    response = client.get(
+        "/api/v1/users?page=2&per_page=5",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data["items"], list)
+    assert len(data["items"]) == 5
+    assert data["meta"]["page"] == 2
+    assert data["meta"]["per_page"] == 5
+
+    response_search = client.get(
+        "/api/v1/users?q=user1",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response_search.status_code == 200
+    data_search = response_search.get_json()
+    assert any("user1" in item.get("email", "") for item in data_search["items"])
+    assert data_search["meta"]["total"] >= 1


### PR DESCRIPTION
## Summary
- add a dedicated user service that handles filtering, search and pagination for list and approval logic
- extend the users API to accept q, page and per_page params and include pagination metadata
- enhance the admin users page with filters and pagination controls and document the new API options
- add regression tests covering the new API behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4cb556fec8326a1fe9c4728bc1020