### PR TITLE
Add refresh token denylist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ REFRESH="<Pega_aquí_el_refresh_token>"
 curl -s -X POST "$BASE/api/v1/auth/refresh" -H "Content-Type: application/json" \
   -d "{\"refresh_token\":\"$REFRESH\"}"
 
+### Denylist y cierre de sesión
+- `POST /api/v1/auth/logout`  \
+  Revoca **ese** refresh (enviar como `Authorization: Bearer <refresh>` o body `{"refresh_token": "..."}`).
+
+- `POST /api/v1/auth/logout_all` *(requiere access token)*  \
+  Revoca **todos** los refresh del usuario (cierre de sesión global).
+
 ### Rate-limit de login
 - Límite: **5 intentos por minuto por IP** (HTTP 429 al exceder).
 ```

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -293,6 +293,7 @@ def load_user(user_id: str) -> User | None:
 from app.models.asset import Asset  # noqa: E402,F401
 from app.models.folder import Folder  # noqa: E402,F401
 from app.models.invite import Invite  # noqa: E402,F401
+from app.models.refresh_token import RefreshToken  # noqa: E402,F401
 
 
 __all__ = [
@@ -308,5 +309,6 @@ __all__ = [
     "DailyChecklistItem",
     "Todo",
     "Invite",
+    "RefreshToken",
     "User",
 ]

--- a/app/models/refresh_token.py
+++ b/app/models/refresh_token.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.extensions import db
+
+
+class RefreshToken(db.Model):
+    __tablename__ = "refresh_tokens"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    jti = db.Column(db.String(64), nullable=False, unique=True, index=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    expires_at = db.Column(db.DateTime, nullable=False)
+    revoked = db.Column(db.Boolean, nullable=False, default=False)
+
+
+__all__ = ["RefreshToken"]

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 from flask import Blueprint, g, jsonify, request, session
 
-from app.services.auth_service import verify_credentials
-from app.security.jwt import decode_jwt, encode_jwt, encode_refresh_jwt
-from app.security.guards import requires_auth
 from app.extensions import limiter
+from app.security.guards import requires_auth
+from app.security.jwt import decode_jwt, encode_jwt, encode_refresh_jwt, gen_jti
+from app.services.auth_service import verify_credentials
+from app.services.token_service import (
+    create_refresh_record,
+    is_active,
+    revoke_all_for_user,
+    revoke_jti,
+)
 
 bp = Blueprint("auth_api", __name__, url_prefix="/api/v1/auth")
 
@@ -16,11 +22,15 @@ bp = Blueprint("auth_api", __name__, url_prefix="/api/v1/auth")
 @limiter.limit("5 per minute")
 def login() -> tuple[object, int]:
     """Validate credentials and return a JWT token."""
+
     payload = request.get_json(force=True, silent=True) or {}
     email = payload.get("email")
     password = payload.get("password")
 
-    user = verify_credentials(str(email) if email is not None else None, str(password) if password is not None else None)
+    user = verify_credentials(
+        str(email) if email is not None else None,
+        str(password) if password is not None else None,
+    )
     if user is None:
         return jsonify({"detail": "invalid credentials"}), 401
 
@@ -28,8 +38,14 @@ def login() -> tuple[object, int]:
         return jsonify({"detail": "not approved"}), 403
 
     role = getattr(user, "role", "user")
-    access_token = encode_jwt({"sub": user.id, "email": user.email, "role": role}, ttl_seconds=15 * 60)
-    refresh_token = encode_refresh_jwt({"sub": user.id, "email": user.email, "role": role})
+    access_token = encode_jwt(
+        {"sub": user.id, "email": user.email, "role": role}, ttl_seconds=15 * 60
+    )
+    refresh_jti = gen_jti()
+    refresh_token = encode_refresh_jwt(
+        {"sub": user.id, "email": user.email, "role": role}, jti=refresh_jti
+    )
+    create_refresh_record(user_id=user.id, jti=refresh_jti)
     session["token"] = access_token
     return (
         jsonify(
@@ -47,6 +63,7 @@ def login() -> tuple[object, int]:
 @requires_auth
 def me() -> tuple[object, int]:
     """Return current user basic information."""
+
     return jsonify({"email": g.current_user_email, "role": g.current_user_role}), 200
 
 
@@ -70,14 +87,30 @@ def refresh() -> tuple[object, int]:
     if data.get("typ") != "refresh":
         return jsonify({"detail": "invalid refresh"}), 401
 
+    sub = data.get("sub")
+    old_jti = data.get("jti")
+    try:
+        sub_int = int(sub)
+    except (TypeError, ValueError):
+        return jsonify({"detail": "invalid refresh"}), 401
+
+    if not old_jti:
+        return jsonify({"detail": "invalid refresh"}), 401
+
+    if not is_active(old_jti, user_id=sub_int):
+        return jsonify({"detail": "refresh revoked or expired"}), 401
+
+    revoke_jti(old_jti)
+
     role = data.get("role", "user")
     access_token = encode_jwt(
-        {"sub": data.get("sub"), "email": data.get("email"), "role": role},
-        ttl_seconds=15 * 60,
+        {"sub": sub_int, "email": data.get("email"), "role": role}, ttl_seconds=15 * 60
     )
+    new_jti = gen_jti()
     refresh_token = encode_refresh_jwt(
-        {"sub": data.get("sub"), "email": data.get("email"), "role": role}
+        {"sub": sub_int, "email": data.get("email"), "role": role}, jti=new_jti
     )
+    create_refresh_record(user_id=sub_int, jti=new_jti)
     session["token"] = access_token
     return (
         jsonify(
@@ -89,3 +122,43 @@ def refresh() -> tuple[object, int]:
         ),
         200,
     )
+
+
+@bp.post("/logout")
+def logout() -> tuple[object, int]:
+    """Revoke a specific refresh token."""
+
+    auth_header = request.headers.get("Authorization", "")
+    body = request.get_json(silent=True) or {}
+
+    token: str | None = None
+    if auth_header.startswith("Bearer "):
+        token = auth_header.split(" ", 1)[1].strip()
+    if not token:
+        token = body.get("refresh_token")
+
+    if not token:
+        return jsonify({"detail": "refresh token required"}), 400
+
+    data = decode_jwt(token) or {}
+    if data.get("typ") != "refresh" or "jti" not in data:
+        return jsonify({"detail": "invalid refresh"}), 401
+
+    revoke_jti(str(data["jti"]))
+    session.pop("token", None)
+    return jsonify({"detail": "logged out"}), 200
+
+
+@bp.post("/logout_all")
+@requires_auth
+def logout_all() -> tuple[object, int]:
+    """Revoke all refresh tokens for the authenticated user."""
+
+    try:
+        user_id = int(g.current_user_id)
+    except (TypeError, ValueError):  # pragma: no cover - guard should ensure int convertible
+        return jsonify({"detail": "invalid user"}), 400
+
+    revoke_all_for_user(user_id)
+    session.pop("token", None)
+    return jsonify({"detail": "all sessions revoked"}), 200

--- a/app/security/jwt.py
+++ b/app/security/jwt.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 
 import jwt
 from flask import current_app
@@ -32,5 +33,12 @@ def decode_jwt(token: str) -> dict | None:
         return None
 
 
-def encode_refresh_jwt(payload: dict, ttl_seconds: int = 7 * 24 * 3600) -> str:
-    return encode_jwt(payload, ttl_seconds=ttl_seconds, typ="refresh")
+def gen_jti() -> str:
+    return uuid.uuid4().hex
+
+
+def encode_refresh_jwt(
+    payload: dict, ttl_seconds: int = 7 * 24 * 3600, jti: str | None = None
+) -> str:
+    token_jti = jti or gen_jti()
+    return encode_jwt({**payload, "jti": token_jti}, ttl_seconds=ttl_seconds, typ="refresh")

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from app.extensions import db
+from app.models.refresh_token import RefreshToken
+
+REFRESH_TTL_DAYS = 7
+
+
+def _expiry() -> datetime:
+    return datetime.utcnow() + timedelta(days=REFRESH_TTL_DAYS)
+
+
+def create_refresh_record(user_id: int, jti: str) -> RefreshToken:
+    row = RefreshToken(user_id=user_id, jti=jti, expires_at=_expiry(), revoked=False)
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def revoke_jti(jti: str) -> int:
+    updated = (
+        RefreshToken.query.filter_by(jti=jti, revoked=False)
+        .update({"revoked": True}, synchronize_session=False)
+    )
+    db.session.commit()
+    return updated
+
+
+def revoke_all_for_user(user_id: int) -> int:
+    updated = (
+        RefreshToken.query.filter_by(user_id=user_id, revoked=False)
+        .update({"revoked": True}, synchronize_session=False)
+    )
+    db.session.commit()
+    return updated
+
+
+def is_active(jti: str, user_id: int) -> bool:
+    row = RefreshToken.query.filter_by(jti=jti, user_id=user_id).first()
+    if row is None:
+        return False
+    if row.revoked:
+        return False
+    if row.expires_at <= datetime.utcnow():
+        return False
+    return True

--- a/migrations/versions/20250924_add_refresh_tokens_table.py
+++ b/migrations/versions/20250924_add_refresh_tokens_table.py
@@ -1,0 +1,32 @@
+"""add refresh_tokens table"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20250924_add_refresh_tokens_table"
+down_revision = "20250924_add_approval_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("jti", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked", sa.Boolean(), nullable=False),
+    )
+    op.create_index("ix_refresh_tokens_user_id", "refresh_tokens", ["user_id"])
+    op.create_index("ix_refresh_tokens_jti", "refresh_tokens", ["jti"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_refresh_tokens_jti", table_name="refresh_tokens")
+    op.drop_index("ix_refresh_tokens_user_id", table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")

--- a/tests/auth/test_refresh_denylist.py
+++ b/tests/auth/test_refresh_denylist.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from werkzeug.security import generate_password_hash
+
+from app.extensions import db
+from app.models import User
+
+
+def _admin(email: str = "adm@a.com", pwd: str = "x") -> User:
+    user = User(
+        email=email,
+        username=email,
+        password_hash=generate_password_hash(pwd),
+        is_active=True,
+        is_approved=True,
+    )
+    try:
+        user.role = "admin"
+    except Exception:  # pragma: no cover - defensive
+        pass
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _login(client, email: str, pwd: str) -> tuple[int, str | None, str | None]:
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": pwd},
+    )
+    data = response.get_json() or {}
+    return response.status_code, data.get("access_token"), data.get("refresh_token")
+
+
+def test_refresh_rotation_blocks_reuse(client, app_ctx):
+    _admin()
+    status, access_token, refresh_token = _login(client, "adm@a.com", "x")
+    assert status == 200 and access_token and refresh_token
+
+    first = client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_token})
+    first_payload = first.get_json() or {}
+    assert first.status_code == 200 and first_payload.get("refresh_token")
+
+    second = client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert second.status_code == 401
+
+
+def test_logout_and_logout_all(client, app_ctx):
+    _admin("adm2@a.com")
+    status, access_token, refresh_token = _login(client, "adm2@a.com", "x")
+    assert status == 200 and access_token and refresh_token
+
+    logout_resp = client.post("/api/v1/auth/logout", json={"refresh_token": refresh_token})
+    assert logout_resp.status_code == 200
+
+    reuse = client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert reuse.status_code == 401
+
+    status2, access2, refresh2 = _login(client, "adm2@a.com", "x")
+    assert status2 == 200 and access2 and refresh2
+
+    logout_all_resp = client.post(
+        "/api/v1/auth/logout_all",
+        headers={"Authorization": f"Bearer {access2}"},
+    )
+    assert logout_all_resp.status_code == 200
+
+    reuse_after_all = client.post("/api/v1/auth/refresh", json={"refresh_token": refresh2})
+    assert reuse_after_all.status_code == 401


### PR DESCRIPTION
## Summary
- add a `refresh_tokens` table and SQLAlchemy model to persist refresh token JTIs
- implement a token service plus JWT changes to generate JTIs and manage refresh token rotation
- update the auth API for rotation, logout endpoints, and document/test the denylist behaviour

## Testing
- APP_ENV=development alembic -c migrations/alembic.ini upgrade head
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d4cc1a6700832694d30a820992c76b