### PR TITLE
Add CORS support and user/IP aware rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,25 @@ En Render puedes crear un **cron job** (o servicio programado) que ejecute ese c
 
 - Configura el nivel con `LOG_LEVEL` (`INFO` por defecto).
 - Los eventos clave (`login_ok`, `login_failed`, `login_not_approved`, `refresh_ok`, `refresh_revoked_or_expired`, `logout_ok`, `logout_all_ok`, `logout_missing_token`, `logout_invalid_refresh`) se emiten en JSON a stdout, listo para agregadores.
+
+## CORS y límites por endpoint
+
+Configura orígenes permitidos (separados por coma):
+
+```bash
+# Render → Settings → Environment
+CORS_ORIGINS=https://mi-frontend.com,https://admin.miapp.com
+```
+
+Rutas CORS:
+
+- Se aplica **solo** a `/api/*` (el panel `/admin/*` no expone CORS).
+
+Límites por endpoint (por usuario o IP):
+
+- `POST /api/v1/auth/login` → **5/min** por IP
+- `POST /api/v1/auth/refresh` → **20/min** por usuario/IP
+- `GET /api/v1/auth/me` → **120/min** por usuario/IP
+- `GET /api/v1/users` → **60/min** por usuario/IP
+- `PATCH /api/v1/users/:id/approve` → **30/min** por usuario/IP
+- `GET /api/v1/users/export.csv` → **10/min** por usuario/IP

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask
+from flask_cors import CORS
 from pytz import timezone
 from .cli_sync import register_sync_cli
 from .config import load_config
@@ -119,6 +120,21 @@ def create_app(config_name: str | None = None) -> Flask:
     init_migrations(app, db)
     init_auth_extensions(app)
     limiter.init_app(app)
+
+    # CORS para la API (se limita a rutas /api/*)
+    origins_env = os.getenv("CORS_ORIGINS", "")
+    origins = [origin.strip() for origin in origins_env.split(",") if origin.strip()] or [
+        "http://localhost:3000"
+    ]
+    CORS(
+        app,
+        resources={r"/api/*": {"origins": origins}},
+        supports_credentials=False,
+        methods=["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type"],
+        expose_headers=["Content-Disposition"],
+        max_age=600,
+    )
 
     set_security_headers(app)
 

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from flask import Blueprint, current_app, jsonify, request
 
+from app.extensions import limiter, user_or_ip
 from app.security.guards import requires_auth, requires_role
 from app.services.user_service import approve_user as service_approve_user
 from app.services.user_service import list_users as service_list_users
@@ -37,6 +38,7 @@ def _serialize_user(user: Any) -> dict[str, Any]:
 @bp.get("/users")
 @requires_auth
 @requires_role("admin")
+@limiter.limit("60 per minute", key_func=user_or_ip)
 def list_users():
     """Return users supporting filters, search and pagination."""
 
@@ -80,6 +82,7 @@ def list_users():
 @bp.patch("/users/<int:user_id>/approve")
 @requires_auth
 @requires_role("admin")
+@limiter.limit("30 per minute", key_func=user_or_ip)
 def approve_user(user_id: int):
     try:
         user = service_approve_user(user_id)

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -21,6 +21,20 @@ db = SQLAlchemy()
 limiter = Limiter(key_func=get_remote_address, headers_enabled=True, default_limits=[])
 
 
+def user_or_ip():
+    """Usa el identificador de usuario autenticado si existe; si no, la IP."""
+    try:
+        from flask import g
+
+        user_id = getattr(g, "current_user_id", None)
+        if user_id:
+            return f"user:{user_id}"
+    except Exception:  # pragma: no cover - fallback seguro
+        pass
+
+    return get_remote_address()
+
+
 def init_auth_extensions(app):
     """Inicializa las extensiones relacionadas con autenticación."""
     bcrypt.init_app(app)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -6,7 +6,7 @@ import logging
 
 from flask import Blueprint, g, jsonify, request, session
 
-from app.extensions import limiter
+from app.extensions import limiter, user_or_ip
 from app.security.guards import requires_auth
 from app.security.jwt import decode_jwt, encode_jwt, encode_refresh_jwt, gen_jti
 from app.services.auth_service import verify_credentials
@@ -87,6 +87,7 @@ def login() -> tuple[object, int]:
 
 @bp.get("/me")
 @requires_auth
+@limiter.limit("120 per minute", key_func=user_or_ip)
 def me() -> tuple[object, int]:
     """Return current user basic information."""
 
@@ -94,6 +95,7 @@ def me() -> tuple[object, int]:
 
 
 @bp.post("/refresh")
+@limiter.limit("20 per minute", key_func=user_or_ip)
 def refresh() -> tuple[object, int]:
     """Issue a new access/refresh pair using a refresh token."""
 
@@ -179,6 +181,7 @@ def refresh() -> tuple[object, int]:
 
 
 @bp.post("/logout")
+@limiter.limit("30 per minute", key_func=user_or_ip)
 def logout() -> tuple[object, int]:
     """Revoke a specific refresh token."""
 
@@ -214,6 +217,7 @@ def logout() -> tuple[object, int]:
 
 @bp.post("/logout_all")
 @requires_auth
+@limiter.limit("10 per minute", key_func=user_or_ip)
 def logout_all() -> tuple[object, int]:
     """Revoke all refresh tokens for the authenticated user."""
 

--- a/render.yaml
+++ b/render.yaml
@@ -15,3 +15,5 @@ services:
           property: connectionString
       - key: SECRET_KEY
         generateValue: true
+      - key: CORS_ORIGINS
+        value: https://localhost:3000

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Flask-Login>=0.6.3
 Flask-Bcrypt>=1.0.1
 Flask-WTF>=1.2.1
 Flask-Limiter>=3.7.0
+Flask-Cors>=4.0.0
 PyJWT>=2.9.0
 email-validator>=2.2.0
 

--- a/tests/security/test_cors.py
+++ b/tests/security/test_cors.py
@@ -1,0 +1,25 @@
+"""Tests básicos de configuración CORS para la API."""
+
+from __future__ import annotations
+
+
+def test_cors_simple_get(client):
+    response = client.get("/healthz", headers={"Origin": "http://localhost:3000"})
+    # /healthz no está bajo /api, por lo que no debe exponer cabeceras CORS.
+    assert "Access-Control-Allow-Origin" not in response.headers
+
+
+def test_cors_api_preflight(client):
+    response = client.options(
+        "/api/v1/auth/login",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "content-type,authorization",
+        },
+    )
+
+    assert response.status_code in (200, 204)
+    assert response.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+    allow_methods = response.headers.get("Access-Control-Allow-Methods", "")
+    assert "POST" in allow_methods


### PR DESCRIPTION
## Summary
- configure Flask-CORS on the API with configurable allowed origins
- add a reusable limiter key that prefers the authenticated user over the IP and apply per-endpoint limits
- document the new settings, render environment variable, and cover the behaviour with CORS tests

## Testing
- pip install -r requirements.txt
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4dc0939e88326ada51bc48d482c70