### PR TITLE
ci: enforce branch coverage with single uploader

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+branch = True
+parallel = True
+source =
+    app
+omit =
+    */migrations/*
+    */tests/*
+    */templates/*
+    */static/*
+
+[report]
+skip_empty = True
+show_missing = True

--- a/.github/workflows/ci-coverage-stable.yml
+++ b/.github/workflows/ci-coverage-stable.yml
@@ -1,0 +1,39 @@
+name: CI (stable coverage)
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-cov coverage
+      - name: Run tests (with coverage)
+        run: |
+          pytest
+          test -f coverage.xml || { echo "coverage.xml missing"; exit 1; }
+      - name: Upload coverage to Codecov (OIDC)
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          use_oidc: true
+          verbose: true
+          fail_ci_if_error: true

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -57,14 +57,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Upload coverage to Codecov - ${{ matrix.part }}
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage-${{ matrix.part }}.xml
-          flags: ${{ matrix.part }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: true
+      # (Coverage uploads centralizados en ci-coverage-stable.yml)
 
   coverage-all:
     runs-on: ubuntu-latest
@@ -100,11 +93,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
-      - name: Upload combined coverage
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.xml
-          flags: all
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: true
+      # (Coverage uploads centralizados en ci-coverage-stable.yml)

--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -78,11 +78,4 @@ jobs:
           files: junit.xml
           flags: lite
           token: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload coverage (one file)
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.xml
-          flags: lite
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: false
+      # (Coverage upload centralizado en ci-coverage-stable.yml)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,108 +1,32 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
 
 coverage:
   precision: 2
   round: down
-  range: 50..90
-
+  range: 60..95
   status:
     project:
       default:
-        target: auto
-        threshold: 2%
-        informational: true
+        target: 70%
+        threshold: 1%
+        informational: false
+        only_pulls: true
     patch:
       default:
-        target: auto
-        threshold: 2%
-        informational: true
-
-    # Metas por flag (ver sección flags)
-    flags:
-      api:
-        target: 80
-        threshold: 2%
-        informational: true
-      auth:
-        target: 80
-        threshold: 2%
-        informational: true
-      models:
-        target: 80
-        threshold: 2%
-        informational: true
-      routes:
-        target: 80
-        threshold: 2%
-        informational: true
-      services:
-        target: 80
-        threshold: 2%
-        informational: true
-      utils:
-        target: 80
-        threshold: 2%
-        informational: true
+        target: 70%
+        threshold: 0%
+        informational: false
+        only_pulls: true
 
 ignore:
-  - "tests/**"
   - "migrations/**"
-  - "docs/**"
-  - "static/**"
-  - "templates/**"
-  - "wsgi.py"
-  - "manage.py"
-  - "render.yaml"
-  - "seed_and_scan.sh"
-  - "verify_metrics.sh"
-  - "create_pr_ui_logo.sh"
-  - "runtime.txt"
-  - "Procfile"
+  - "tests/**"
+  - "app/templates/**"
+  - "app/static/**"
 
 flags:
-  api:
-    paths:
-      - app/api/
-  auth:
-    paths:
-      - app/auth/
-      - app/simple_auth/
-  models:
-    paths:
-      - app/models/
-  routes:
-    paths:
-      - app/routes/
-      - app/blueprints/
-  services:
-    paths:
-      - app/services/
-  utils:
-    paths:
-      - app/utils/
-
-component_management:
-  individual_components:
-    - name: API
-      paths:
-        - app/api/**
-    - name: Auth
-      paths:
-        - app/auth/**
-        - app/simple_auth/**
-    - name: Models
-      paths:
-        - app/models/**
-    - name: Routes
-      paths:
-        - app/routes/**
-        - app/blueprints/**
-    - name: Services
-      paths:
-        - app/services/**
-    - name: Utils
-      paths:
-        - app/utils/**
-
-comment: false
+  unit:
+    carryforward: true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
-addopts = -ra
+addopts = -ra --maxfail=1 --disable-warnings --cov=app --cov-branch --cov-report=xml --cov-report=term


### PR DESCRIPTION
## Summary
- enforce branch coverage generation across pytest runs via pytest.ini defaults and dedicated .coveragerc
- add a stable coverage CI workflow using checkout fetch-depth 0 and Codecov OIDC upload while removing duplicate uploads from existing workflows
- tighten Codecov configuration thresholds to avoid missing-base errors and require CI to finish

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4e4e9b4988326beb82df33e0de817