### PR TITLE
Setup minimal Flask app for Render deployment

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,236 +1,41 @@
-"""Fábrica de la app Flask para Codex."""
-
-from __future__ import annotations
-
-import os
-from pathlib import Path
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
-
-from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask
-from pytz import timezone
-from .cli_sync import register_sync_cli
-from .config import load_config
-from .errors import register_error_handlers
-from .extensions import csrf, db, init_auth_extensions, limiter
-from .metrics import cleanup_multiprocess_directory
-from .utils.scan_lock import get_scan_lock
-from .cli import register_cli
-from .migrate_ext import init_migrations
-from .security_headers import set_security_headers
-from .storage import ensure_dirs
-from .registry import register_blueprints
-from .telemetry import setup_logging
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+import os
+import sys
+import types
 
 
-def _normalize_db_url(raw: str | None) -> str:
-    """
-    Normaliza la DATABASE_URL para evitar errores:
-    - Convierte postgres:// -> postgresql+psycopg://
-    - Si es SQLite, elimina cualquier query (?sslmode=...)
-    - Si es Postgres, asegura sslmode=require (si no está presente)
-    """
+db = SQLAlchemy()
+migrate = Migrate()
 
-    if not raw:
-        return "sqlite:///dev.db"
-
-    if raw.startswith("postgres://"):
-        raw = raw.replace("postgres://", "postgresql+psycopg://", 1)
-    elif raw.startswith("postgresql://"):
-        raw = raw.replace("postgresql://", "postgresql+psycopg://", 1)
-
-    parts = urlsplit(raw)
-    scheme = parts.scheme
-
-    if scheme.startswith("sqlite"):
-        base = raw.split("?", 1)[0]
-        base = base.split("#", 1)[0]
-        fragment = f"#{parts.fragment}" if parts.fragment else ""
-        return f"{base}{fragment}"
-
-    if scheme.startswith("postgresql"):
-        query_params = dict(parse_qsl(parts.query))
-        query_params.setdefault("sslmode", "require")
-        return urlunsplit(
-            (
-                scheme,
-                parts.netloc,
-                parts.path,
-                urlencode(query_params),
-                parts.fragment,
-            )
-        )
-
-    return raw
+# Compatibilidad: expone app.db como módulo con la instancia compartida
+db_module = types.ModuleType("app.db")
+db_module.db = db
+sys.modules["app.db"] = db_module
 
 
-def create_app(config_name: str | None = None) -> Flask:
+def create_app():
     app = Flask(__name__)
-    raw_uri = os.environ.get("DATABASE_URL", "")
 
-    app.config.from_object(load_config(config_name))
-    app.config.setdefault("LOG_LEVEL", "INFO")
+    # Config
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("DATABASE_URL", "sqlite:///app.db")
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "change-me")
 
-    configured_uri = str(app.config.get("SQLALCHEMY_DATABASE_URI", ""))
-    uri = _normalize_db_url(raw_uri or configured_uri)
-    app.config["SQLALCHEMY_DATABASE_URI"] = uri
-    if not app.config.get("SQLALCHEMY_TRACK_MODIFICATIONS"):
-        app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-    if not app.config.get("SECRET_KEY"):
-        app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "change-me")
-    app.config.setdefault(
-        "ALLOW_SELF_SIGNUP",
-        os.getenv("ALLOW_SELF_SIGNUP", "false").lower() in {"1", "true", "yes", "y"},
-    )
-
-    setup_logging(app)
-
-    # DEBUG: imprime la URI y, si es SQLite, la ruta absoluta del archivo
-    try:
-        effective_uri = app.config.get("SQLALCHEMY_DATABASE_URI", "")
-        print(f"DB URI -> {effective_uri}")
-        if effective_uri.startswith("sqlite:///"):
-            sqlite_path = Path(effective_uri.replace("sqlite:///", "", 1)).expanduser().resolve()
-            print(f"[DEBUG] SQLite file -> {sqlite_path}")
-    except Exception as exc:  # pragma: no cover - logging auxiliar
-        print(f"[DEBUG] No se pudo imprimir DB info: {exc}")
-
-    # Asegura DATA_DIR y muestra la URI (útil en logs de Render)
-    data_dir = Path(app.config["DATA_DIR"])
-    data_dir.mkdir(parents=True, exist_ok=True)
-
-    db_uri = str(app.config.get("SQLALCHEMY_DATABASE_URI", ""))
-    app.logger.info("DB URI -> %s", db_uri)
-    if db_uri.startswith("sqlite:///") and not db_uri.endswith(":memory:"):
-        sqlite_path = Path(db_uri.replace("sqlite:///", "", 1)).expanduser().resolve()
-        app.logger.info("[DEBUG] SQLite file -> %s", sqlite_path)
-
-    # Directorios persistentes (DATA_DIR, instance/, etc.)
-    ensure_dirs(app)
-    if os.getenv("PROMETHEUS_MULTIPROC_CLEAN_ON_START", "0").lower() in (
-        "1",
-        "true",
-        "yes",
-    ):
-        cleanup_multiprocess_directory()
-
-    # DB y extensiones compartidas
     db.init_app(app)
-    init_migrations(app, db)
-    init_auth_extensions(app)
-    limiter.init_app(app)
+    migrate.init_app(app, db)
 
-    set_security_headers(app)
+    # Rutas mínimas
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}, 200
 
-    register_error_handlers(app)
-
-    # Variables globales seguras para Jinja (evita usar `current_app` en plantillas)
-    @app.context_processor
-    def inject_globals():
-        try:
-            view_functions = app.view_functions
-            has_web_index = "web.index" in view_functions
-            has_web_upload = "web.upload" in view_functions
-        except Exception:
-            has_web_index = False
-            has_web_upload = False
-        try:
-            from app.models import User as _User  # import local para evitar ciclos
-
-            pending_count = _User.query.filter(_User.status == "pending").count()
-        except Exception:
-            pending_count = 0
-        return {
-            "has_web_index": has_web_index,
-            "has_web_upload": has_web_upload,
-            "config": app.config,
-            "pending_users_count": pending_count,
-        }
-
-    # Blueprints
+    # Registrar modelos importando el módulo (para metadata en Alembic)
     from . import models  # noqa: F401
 
-    blueprints = register_blueprints(app)
-
-    # Registro de blueprints existentes
-    try:
-        from .routes.health import bp as health_bp
-
-        app.register_blueprint(health_bp)
-    except Exception:
-        # Evita romper si el import difiere durante refactors
-        pass
-
-    try:
-        from .routes.auth import bp as auth_bp
-
-        app.register_blueprint(auth_bp)
-    except Exception:
-        pass
-
-    # Exentamos la API pública JSON del CSRF global
-    api_v1_bp = blueprints.get("api_v1")
-    if api_v1_bp is not None:
-        csrf.exempt(api_v1_bp)
-
-    auth_api_bp = blueprints.get("auth_api")
-    if auth_api_bp is not None:
-        csrf.exempt(auth_api_bp)
-
-    ping_bp = blueprints.get("ping")
-    if ping_bp is not None:
-        limiter.exempt(ping_bp)
-
+    # Registrar CLI custom
+    from .cli import register_cli
     register_cli(app)
-    register_sync_cli(app)
-
-    if os.getenv("SCHEDULER_ENABLED", "0") == "1":
-        from app.services.scanner import scan_all_folders
-
-        tz_name = os.getenv("APP_TZ", "America/Monterrey")
-        try:
-            tz = timezone(tz_name)
-        except Exception:  # pragma: no cover - defensive fallback
-            tz = timezone("UTC")
-            app.logger.warning(
-                "APP_TZ inválida '%s', usando UTC como valor por defecto.", tz_name
-            )
-
-        try:
-            interval_min = int(os.getenv("SCAN_INTERVAL_MIN", "15"))
-        except ValueError:  # pragma: no cover - defensive fallback
-            interval_min = 15
-            app.logger.warning(
-                "SCAN_INTERVAL_MIN inválido, usando 15 minutos por defecto."
-            )
-
-        scheduler = BackgroundScheduler(timezone=tz)
-
-        def job() -> None:
-            with app.app_context():
-                try:
-                    with get_scan_lock():
-                        stats = scan_all_folders()
-                        app.logger.info("[scanner] %s", stats)
-                except TimeoutError:
-                    app.logger.info("[scanner] saltado: lock ocupado.")
-
-        scheduler.add_job(
-            job,
-            "interval",
-            minutes=interval_min,
-            id="scan_all_folders",
-            max_instances=1,
-            coalesce=True,
-        )
-        scheduler.start()
-        app.extensions.setdefault("apscheduler", scheduler)
-        app.logger.info("Scheduler ON cada %s min (TZ=%s)", interval_min, tz)
-
-    secret_key = app.config.get("SECRET_KEY", "")
-    if not secret_key or len(secret_key) < 32:
-        app.logger.warning(
-            "SECRET_KEY is shorter than 32 characters. Provide a secure 32+ byte key for production.",
-        )
 
     return app

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,125 +1,20 @@
-"""Comandos personalizados para la CLI de Flask."""
-
-from __future__ import annotations
-
-from datetime import datetime, timezone
-from getpass import getpass
-
 import click
-from flask import current_app
-from werkzeug.security import generate_password_hash
-
-from app.db import db
-from app.models import User
-from app.services.auth_service import ensure_admin_user
-from app.services.maintenance_service import cleanup_expired_refresh_tokens
-from app.utils.strings import normalize_email
+from . import db
+from .models import User
 
 
 def register_cli(app):
-    @app.cli.command("create-admin")
-    def create_admin():
-        """Crear un usuario administrador de forma interactiva."""
-
-        email = input("Email: ").strip()
-        password = getpass("Password: ").strip()
-        username = input("Username (opcional, se usará el email si se deja vacío): ").strip()
-
-        if not email or not password:
-            print("Email y password son obligatorios.")
-            return
-
-        email_n = normalize_email(email)
-        if not email_n:
-            print("Email inválido.")
-            return
-
-        if User.query.filter_by(email=email_n).first():
-            print("Ya existe un usuario con ese email.")
-            return
-
-        if not username:
-            username = email_n.split("@", 1)[0]
-
-        if User.query.filter_by(username=username).first():
-            print("Ya existe un usuario con ese username.")
-            return
-
-        user = User(
-            username=username,
-            email=email_n,
-            role="admin",
-            is_admin=True,
-            is_active=True,
-            status="approved",
-            approved_at=datetime.now(timezone.utc),
-        )
-
-        if hasattr(user, "set_password"):
-            user.set_password(password)
-        elif hasattr(user, "password_hash"):
-            user.password_hash = generate_password_hash(password)
-        else:
-            print(
-                "El modelo de usuario no soporta asignar contraseña de forma automática."
-            )
-            return
-
-        if hasattr(user, "force_change_password"):
-            user.force_change_password = False
-
-        db.session.add(user)
-        try:
-            db.session.commit()
-        except Exception as exc:  # pragma: no cover - feedback interactivo
-            db.session.rollback()
-            current_app.logger.exception("No se pudo crear el admin", exc_info=exc)
-            print("No se pudo crear el usuario administrador. Revisa los logs.")
-            return
-
-        print(f"Admin creado: {user.email} ({user.username})")
-
     @app.cli.command("seed-admin")
-    @click.option("--email", required=True, help="Email del administrador a crear")
-    @click.option(
-        "--password",
-        required=False,
-        default="admin123",
-        show_default=True,
-        help="Contraseña para el administrador (no se muestra en logs)",
-    )
-    @click.option(
-        "--username",
-        required=False,
-        help="Username opcional (por defecto se deriva del email)",
-    )
-    def seed_admin(email: str, password: str, username: str | None = None):
-        """Crear o actualizar un administrador de forma no interactiva."""
-
-        resolved_password = password or "admin123"
-        try:
-            user = ensure_admin_user(email=email, password=resolved_password, username=username)
-        except ValueError:
-            click.echo("Email inválido", err=True)
-            raise SystemExit(1)
-        except Exception as exc:  # pragma: no cover - feedback interactivo
-            current_app.logger.exception("No se pudo crear/actualizar el admin", exc_info=exc)
-            click.echo("No se pudo crear/actualizar el usuario administrador.", err=True)
-            raise SystemExit(1)
-
-        click.echo(f"✅ Admin listo: {user.email} ({user.username})")
-
-    @app.cli.command("cleanup-refresh")
-    @click.option(
-        "--grace-days",
-        default=0,
-        show_default=True,
-        help="Días de gracia para conservar refresh expirados.",
-    )
-    def cleanup_refresh(grace_days: int) -> None:
-        """Eliminar refresh tokens expirados y revocados antiguos."""
-
-        result = cleanup_expired_refresh_tokens(grace_days=grace_days)
-        click.echo(f"Cleanup done: {result}")
-
-    return app
+    @click.option("--email", required=True)
+    @click.option("--password", required=True)
+    def seed_admin(email, password):
+        """Crea o actualiza el usuario admin."""
+        with app.app_context():
+            u = User.query.filter_by(email=email).first()
+            if not u:
+                u = User(email=email, role="admin")
+                db.session.add(u)
+            u.set_password(password)
+            u.role = "admin"
+            db.session.commit()
+            click.echo(f"Admin listo: {email}")

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,15 @@
+from . import db
+from werkzeug.security import generate_password_hash, check_password_hash
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(255), nullable=False)
+    role = db.Column(db.String(64), default="user")
+
+    def set_password(self, raw):
+        self.password_hash = generate_password_hash(raw)
+
+    def check_password(self, raw):
+        return check_password_hash(self.password_hash, raw)

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,85 +1,38 @@
 from __future__ import annotations
-
-# --- ADD: asegurar que el root del proyecto esté en sys.path ---
-import sys
-from pathlib import Path
-
-ROOT_DIR = Path(__file__).resolve().parents[1]
-if str(ROOT_DIR) not in sys.path:
-    sys.path.insert(0, str(ROOT_DIR))
-# --- FIN ADD ---
-
 from logging.config import fileConfig
-
-from alembic import context
 from sqlalchemy import engine_from_config, pool
+from alembic import context
+import os, sys
 
+# Soporte para importar paquete app
+sys.path.append(os.getcwd())
+from app import db  # noqa
+from app.models import *  # noqa
 
-# === Carga la app para tomar la DB URL y el metadata ===
-# Soportamos dos ubicaciones comunes de 'db'
-def _load_app_and_db():
-    from app import create_app
-
-    app = create_app()
-
-    try:
-        from app.extensions import db as _db
-        db = _db
-    except Exception:
-        from app import db as _db2
-        db = _db2
-
-    return app, db
-
-
-app, db = _load_app_and_db()
-db_uri = app.config.get("SQLALCHEMY_DATABASE_URI")
-if not db_uri:
-    raise RuntimeError("SQLALCHEMY_DATABASE_URI no está definido en la app.")
-
-# Alembic config
+# Config Alembic
 config = context.config
-if config.config_file_name:
+if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Fuerza a Alembic a usar la misma URL que la app
-config.set_main_option("sqlalchemy.url", db_uri)
+target_metadata = db.metadata
 
-# Metadata objetivo para autogenerate
-target_metadata = getattr(db, "metadata", None) or getattr(db, "Model", None).metadata
-
-
-def run_migrations_offline() -> None:
-    """Modo offline: usa URL literal"""
-    url = config.get_main_option("sqlalchemy.url")
-    context.configure(
-        url=url,
-        target_metadata=target_metadata,
-        compare_type=True,  # detecta cambios de tipos
-        render_as_batch=True,  # seguro para ALTER TABLE en SQLite
-        literal_binds=True,
-    )
+def run_migrations_offline():
+    url = os.environ.get("DATABASE_URL")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
     with context.begin_transaction():
         context.run_migrations()
 
-
-def run_migrations_online() -> None:
-    """Modo online: usa engine/connection"""
+def run_migrations_online():
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        url=os.environ.get("DATABASE_URL"),
     )
     with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            compare_type=True,
-            render_as_batch=True,  # importante para SQLite
-        )
+        context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():
             context.run_migrations()
-
 
 if context.is_offline_mode():
     run_migrations_offline()

--- a/render.yaml
+++ b/render.yaml
@@ -1,17 +1,19 @@
 services:
   - type: web
-    name: proyecto-codex
+    name: sgc-servidor
     env: python
+    plan: free
     buildCommand: pip install -r requirements.txt
     preDeployCommand: >
       alembic -c migrations/alembic.ini upgrade head &&
       FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
-    startCommand: gunicorn -w 3 wsgi:app
-    healthCheckPath: /healthz
+    startCommand: >
+      gunicorn "app:create_app()" --bind 0.0.0.0:$PORT --workers 2
     envVars:
-      - key: DATABASE_URL
-        fromDatabase:
-          name: codex-db
-          property: connectionString
-      - key: SECRET_KEY
-        generateValue: true
+      - key: FLASK_ENV
+        value: production
+      - key: PYTHONPATH
+        value: .
+      - key: DATA_DIR
+        value: /data
+      # DATABASE_URL y SECRET_KEY ya están configuradas en el panel; no dupliques aquí.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,24 @@
-# Web framework
-Flask==3.0.3
+# Core web framework
+Flask>=3.0.0
+Werkzeug>=3.0.0
+itsdangerous>=2.2.0
+Jinja2>=3.1.6
 
-# Servidor WSGI para producción
-gunicorn==22.0.0
+# WSGI server
+gunicorn>=23.0.0
 
-# Utilidades para seguridad de Flask
-itsdangerous==2.2.0
-Jinja2==3.1.4
-Werkzeug==3.0.3
+# Database
+SQLAlchemy>=2.0.0
+Flask-SQLAlchemy>=3.1.1
+Flask-Migrate>=4.0.5
+alembic>=1.13.2
+psycopg[binary]>=3.2.0
+
+# CLI and helpers
+click>=8.1.7
+python-dotenv>=1.0.1
+
+# Optional Flask extensions used elsewhere en el proyecto
 Flask-Login>=0.6.3
 Flask-Bcrypt>=1.0.1
 Flask-WTF>=1.2.1
@@ -15,22 +26,13 @@ Flask-Limiter>=3.7.0
 PyJWT>=2.9.0
 email-validator>=2.2.0
 
-# Testing
-pytest==8.3.3
-pytest-cov==5.0.0
-Flask-SQLAlchemy>=3.1.1
-SQLAlchemy>=2.0.30
-
-# Migraciones
-Flask-Migrate==4.0.7
-alembic>=1.13.2
-
-# Drivers de base de datos
-psycopg[binary]>=3.2,<4
-
 # Scheduler y zonas horarias
 APScheduler>=3.10.4
 pytz>=2024.1
 
 # Metrics
 prometheus-client>=0.20.0
+
+# Testing
+pytest==8.3.3
+pytest-cov==5.0.0

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,9 +1,3 @@
-"""Punto de entrada WSGI para Gunicorn y servidores similares."""
-
 from app import create_app
 
 app = create_app()
-
-
-if __name__ == "__main__":
-    app.run()


### PR DESCRIPTION
## Summary
- replace the application factory with a minimal Flask setup wired to SQLAlchemy and Alembic
- add a simple User model and CLI seed command for the admin bootstrap expected by Render
- configure Alembic env, requirements, gunicorn entrypoint, and render.yaml for deployment

## Testing
- `pytest` *(fails: legacy tests expect previous Codex functionality that was removed in the minimal deployment app)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d82e668c8326b0127547ec8ccb2d