### PR TITLE
fix(alembic): shorten revision ids

### DIFF
--- a/migrations/versions/20250924_add_refresh_tokens_table.py
+++ b/migrations/versions/20250924_add_refresh_tokens_table.py
@@ -6,7 +6,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "20250924_add_refresh_tokens_table"
+revision = "rev_20250924_refresh_tokens"
 down_revision = "20250924_add_approval_fields"
 branch_labels = None
 depends_on = None

--- a/tools/check_alembic_ids.py
+++ b/tools/check_alembic_ids.py
@@ -1,0 +1,13 @@
+import pathlib
+import re
+import sys
+
+ok = True
+for path in pathlib.Path("migrations/versions").glob("*.py"):
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"^revision\s*=\s*'([^']+)'", text, re.M)
+    if match and len(match.group(1)) > 32:
+        print(f"[ERROR] {path}: revision '{match.group(1)}' > 32 chars")
+        ok = False
+if not ok:
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- shorten the refresh token migration revision id to keep it within Alembic's 32-character limit
- add a CI helper script to check that future migration revisions stay within the limit

## Testing
- python tools/check_alembic_ids.py

------
https://chatgpt.com/codex/tasks/task_e_68d5dbc9bc7883269db8dc9b33e9de43