### PR TITLE
Update Render predeploy migration script

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,9 +3,15 @@ services:
     name: proyecto-codex
     env: python
     buildCommand: pip install -r requirements.txt
-    preDeployCommand: >
-      alembic -c migrations/alembic.ini upgrade head &&
-      FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
+    preDeployCommand: |
+      python - <<'PY'
+      import os, psycopg
+      with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
+          with conn.cursor() as cur:
+              cur.execute("ALTER TABLE IF EXISTS alembic_version ALTER COLUMN version_num TYPE VARCHAR(64);")
+          conn.commit()
+      PY
+      alembic -c migrations/alembic.ini upgrade head && FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
     startCommand: gunicorn -w 3 wsgi:app
     healthCheckPath: /healthz
     envVars:


### PR DESCRIPTION
## Summary
- run a Python snippet during predeploy to widen alembic_version.version_num
- follow the migration upgrade with the admin seeding command

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5eaf0b5708326bb66b77909c6c350