### PR TITLE
Add equipos CRUD module with seed data

### DIFF
--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -9,4 +9,5 @@ __all__ = [
     "folders",
     "api",
     "ping",
+    "equipos",
 ]

--- a/app/blueprints/equipos/__init__.py
+++ b/app/blueprints/equipos/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+bp = Blueprint("equipos", __name__, url_prefix="/equipos")
+
+from . import routes  # noqa: E402,F401

--- a/app/blueprints/equipos/routes.py
+++ b/app/blueprints/equipos/routes.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from flask import flash, redirect, render_template, request, url_for
+
+from app.db import db
+from app.models import Equipo
+
+from . import bp
+
+
+@bp.get("/")
+def index():
+    q = (request.args.get("q", "") or "").strip()
+    query = Equipo.query
+    if q:
+        like = f"%{q}%"
+        query = query.filter(
+            db.or_(
+                Equipo.codigo.ilike(like),
+                Equipo.tipo.ilike(like),
+                Equipo.marca.ilike(like),
+            )
+        )
+    equipos = query.order_by(Equipo.codigo.asc()).all()
+    return render_template("equipos/index.html", equipos=equipos, q=q)
+
+
+@bp.get("/nuevo")
+def nuevo():
+    return render_template("equipos/form.html", equipo=None)
+
+
+@bp.post("/crear")
+def crear():
+    data = {
+        k: request.form.get(k) for k in [
+            "codigo",
+            "tipo",
+            "marca",
+            "modelo",
+            "serie",
+            "placas",
+            "status",
+            "ubicacion",
+        ]
+    }
+    horas_uso_raw = request.form.get("horas_uso")
+    if horas_uso_raw:
+        try:
+            data["horas_uso"] = float(horas_uso_raw)
+        except (TypeError, ValueError):
+            flash("Horas de uso inválidas", "error")
+            return redirect(url_for("equipos.nuevo"))
+    if not data.get("codigo") or not data.get("tipo"):
+        flash("Código y tipo son obligatorios", "error")
+        return redirect(url_for("equipos.nuevo"))
+    equipo = Equipo(**data)
+    db.session.add(equipo)
+    db.session.commit()
+    flash("Equipo creado", "success")
+    return redirect(url_for("equipos.index"))
+
+
+@bp.get("/<int:equipo_id>/editar")
+def editar(equipo_id: int):
+    equipo = Equipo.query.get_or_404(equipo_id)
+    return render_template("equipos/form.html", equipo=equipo)
+
+
+@bp.post("/<int:equipo_id>/actualizar")
+def actualizar(equipo_id: int):
+    equipo = Equipo.query.get_or_404(equipo_id)
+    for key in [
+        "codigo",
+        "tipo",
+        "marca",
+        "modelo",
+        "serie",
+        "placas",
+        "status",
+        "ubicacion",
+        "horas_uso",
+    ]:
+        value = request.form.get(key)
+        if value is None or value == "":
+            continue
+        if key == "horas_uso":
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                flash("Horas de uso inválidas", "error")
+                return redirect(url_for("equipos.editar", equipo_id=equipo.id))
+        setattr(equipo, key, value)
+    db.session.commit()
+    flash("Equipo actualizado", "success")
+    return redirect(url_for("equipos.index"))
+
+
+@bp.post("/<int:equipo_id>/eliminar")
+def eliminar(equipo_id: int):
+    equipo = Equipo.query.get_or_404(equipo_id)
+    db.session.delete(equipo)
+    db.session.commit()
+    flash("Equipo eliminado", "success")
+    return redirect(url_for("equipos.index"))
+
+
+@bp.get("/<int:equipo_id>")
+def detalle(equipo_id: int):
+    equipo = Equipo.query.get_or_404(equipo_id)
+    return render_template("equipos/detalle.html", equipo=equipo)

--- a/app/cli.py
+++ b/app/cli.py
@@ -10,7 +10,7 @@ from flask import current_app
 from werkzeug.security import generate_password_hash
 
 from app.db import db
-from app.models import User
+from app.models import Equipo, User
 from app.services.auth_service import ensure_admin_user
 from app.services.maintenance_service import cleanup_expired_refresh_tokens
 from app.utils.strings import normalize_email
@@ -121,5 +121,19 @@ def register_cli(app):
 
         result = cleanup_expired_refresh_tokens(grace_days=grace_days)
         click.echo(f"Cleanup done: {result}")
+
+    @app.cli.command("seed-equipos")
+    def seed_equipos():
+        """Cargar equipos de demostración si no existen."""
+
+        data = [
+            {"codigo": "EXC-001", "tipo": "excavadora", "marca": "CAT", "modelo": "320D", "status": "activo"},
+            {"codigo": "DRG-028", "tipo": "draga", "marca": "IHC", "modelo": "28m", "status": "mantenimiento"},
+        ]
+        for payload in data:
+            if not Equipo.query.filter_by(codigo=payload["codigo"]).first():
+                db.session.add(Equipo(**payload))
+        db.session.commit()
+        click.echo("Equipos seed: OK")
 
     return app

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -291,6 +291,7 @@ def load_user(user_id: str) -> User | None:
 
 
 from app.models.asset import Asset  # noqa: E402,F401
+from app.models.equipo import Equipo  # noqa: E402,F401
 from app.models.folder import Folder  # noqa: E402,F401
 from app.models.invite import Invite  # noqa: E402,F401
 from app.models.refresh_token import RefreshToken  # noqa: E402,F401
@@ -308,6 +309,7 @@ __all__ = [
     "DailyChecklist",
     "DailyChecklistItem",
     "Todo",
+    "Equipo",
     "Invite",
     "RefreshToken",
     "User",

--- a/app/models/equipo.py
+++ b/app/models/equipo.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.db import db
+
+
+class Equipo(db.Model):
+    __tablename__ = "equipos"
+
+    id = db.Column(db.Integer, primary_key=True)
+    codigo = db.Column(db.String(64), unique=True, nullable=False, index=True)
+    tipo = db.Column(db.String(64), nullable=False)
+    marca = db.Column(db.String(64))
+    modelo = db.Column(db.String(64))
+    serie = db.Column(db.String(128))
+    placas = db.Column(db.String(32))
+    status = db.Column(db.String(32), default="activo")
+    ubicacion = db.Column(db.String(128))
+    horas_uso = db.Column(db.Float, default=0.0)
+    fecha_alta = db.Column(db.Date, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/app/registry.py
+++ b/app/registry.py
@@ -11,6 +11,7 @@ from app.api.v1.users import bp as users_v1_bp
 from app.blueprints.admin import bp_admin
 from app.blueprints.api.v1 import bp_api_v1
 from app.blueprints.auth import bp_auth
+from app.blueprints.equipos import bp as equipos_bp
 from app.blueprints.ping import bp_ping
 from app.blueprints.web import bp_web
 from app.routes.assets import assets_bp
@@ -26,6 +27,7 @@ def register_blueprints(app: Flask) -> dict[str, Blueprint]:
         (public_bp, {}),
         (bp_auth, {}),
         (bp_web, {}),
+        (equipos_bp, {}),
         (bp_admin, {}),
         (bp_api_v1, {"url_prefix": "/api/v1"}),
         (todos_v1_bp, {}),

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -24,6 +24,9 @@
       {% elif session_user %}
         {% set current_role = session_user.get('role') or ('admin' if session_user.get('is_admin') else None) %}
       {% endif %}
+      <a class="btn btn-outline" href="{{ url_for('equipos.index') }}">
+        <span>Equipos</span>
+      </a>
       <div class="toolbar" style="margin-left:auto">
         {% if is_logged %}
           {% if current_role == "admin" %}

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ equipo.codigo }} — {{ equipo.tipo }}</h1>
+<ul>
+  <li>Marca: {{ equipo.marca or '-' }}</li>
+  <li>Modelo: {{ equipo.modelo or '-' }}</li>
+  <li>Serie: {{ equipo.serie or '-' }}</li>
+  <li>Placas: {{ equipo.placas or '-' }}</li>
+  <li>Status: {{ equipo.status }}</li>
+  <li>Ubicación: {{ equipo.ubicacion or '-' }}</li>
+  <li>Horas de uso: {{ equipo.horas_uso }}</li>
+</ul>
+<a href="{{ url_for('equipos.editar', equipo_id=equipo.id) }}">Editar</a>
+{% endblock %}

--- a/app/templates/equipos/form.html
+++ b/app/templates/equipos/form.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ 'Editar' if equipo else 'Nuevo' }} equipo</h1>
+<form method="post" action="{{ url_for('equipos.actualizar', equipo_id=equipo.id) if equipo else url_for('equipos.crear') }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {% for name,label in [('codigo','Código'),('tipo','Tipo'),('marca','Marca'),('modelo','Modelo'),('serie','Serie'),('placas','Placas'),('status','Status'),('ubicacion','Ubicación'),('horas_uso','Horas de uso')] %}
+    <label>{{ label }} <input name="{{ name }}" value="{{ getattr(equipo, name, '') if equipo else '' }}"></label><br>
+  {% endfor %}
+  <button type="submit">Guardar</button>
+</form>
+{% endblock %}

--- a/app/templates/equipos/index.html
+++ b/app/templates/equipos/index.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Equipos</h1>
+<form method="get" class="mb-3">
+  <input name="q" value="{{ q }}" placeholder="Buscar por código / tipo / marca">
+  <button type="submit">Buscar</button>
+  <a href="{{ url_for('equipos.nuevo') }}">Nuevo</a>
+</form>
+<table>
+  <thead><tr><th>Código</th><th>Tipo</th><th>Marca</th><th>Status</th><th></th></tr></thead>
+  <tbody>
+  {% for equipo in equipos %}
+    <tr>
+      <td><a href="{{ url_for('equipos.detalle', equipo_id=equipo.id) }}">{{ equipo.codigo }}</a></td>
+      <td>{{ equipo.tipo }}</td><td>{{ equipo.marca or '-' }}</td><td>{{ equipo.status }}</td>
+      <td>
+        <a href="{{ url_for('equipos.editar', equipo_id=equipo.id) }}">Editar</a>
+        <form action="{{ url_for('equipos.eliminar', equipo_id=equipo.id) }}" method="post" style="display:inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+        </form>
+      </td>
+    </tr>
+  {% else %}
+    <tr><td colspan="5">No hay equipos registrados.</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/migrations/versions/20251010_create_equipos_table.py
+++ b/migrations/versions/20251010_create_equipos_table.py
@@ -1,0 +1,53 @@
+"""create equipos table"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251010_create_equipos_table"
+down_revision = "rev_20250924_refresh_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "equipos",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("codigo", sa.String(length=64), nullable=False),
+        sa.Column("tipo", sa.String(length=64), nullable=False),
+        sa.Column("marca", sa.String(length=64), nullable=True),
+        sa.Column("modelo", sa.String(length=64), nullable=True),
+        sa.Column("serie", sa.String(length=128), nullable=True),
+        sa.Column("placas", sa.String(length=32), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=True, server_default="activo"),
+        sa.Column("ubicacion", sa.String(length=128), nullable=True),
+        sa.Column(
+            "horas_uso",
+            sa.Float(),
+            nullable=True,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("fecha_alta", sa.Date(), nullable=True, server_default=sa.func.current_date()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("codigo", name="uq_equipos_codigo"),
+    )
+    op.create_index("ix_equipos_codigo", "equipos", ["codigo"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_equipos_codigo", table_name="equipos")
+    op.drop_table("equipos")


### PR DESCRIPTION
## Summary
- add the Equipo model and Alembic migration for the equipos table
- create the equipos blueprint with CRUD views, templates, and navigation entry
- register a CLI seed command to preload sample equipment records

## Testing
- not run (environment lacked the necessary CLI tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d61d629d688326aa6fa6817daccf7d