### PR TITLE
Add operadores module with CRUD pages and seed command

### DIFF
--- a/app/blueprints/operadores/__init__.py
+++ b/app/blueprints/operadores/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+bp = Blueprint("operadores", __name__, url_prefix="/operadores")
+
+from . import routes  # noqa: E402,F401

--- a/app/blueprints/operadores/routes.py
+++ b/app/blueprints/operadores/routes.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from flask import flash, redirect, render_template, request, url_for
+
+from app.db import db
+from app.models import Operador
+
+from . import bp
+
+
+@bp.get("/")
+def index():
+    q = (request.args.get("q", "") or "").strip()
+    query = Operador.query
+    if q:
+        like = f"%{q}%"
+        query = query.filter(
+            db.or_(
+                Operador.nombre.ilike(like),
+                Operador.identificacion.ilike(like),
+                Operador.puesto.ilike(like),
+            )
+        )
+    operadores = query.order_by(Operador.nombre.asc()).all()
+    return render_template("operadores/index.html", operadores=operadores, q=q)
+
+
+@bp.get("/nuevo")
+def nuevo():
+    return render_template("operadores/form.html", op=None)
+
+
+@bp.post("/crear")
+def crear():
+    data = {
+        k: request.form.get(k)
+        for k in ["nombre", "identificacion", "licencia", "puesto", "telefono", "status"]
+    }
+    if not (data.get("nombre") or "").strip():
+        flash("El nombre es obligatorio", "error")
+        return redirect(url_for("operadores.nuevo"))
+    operador = Operador(**data)
+    db.session.add(operador)
+    db.session.commit()
+    flash("Operador creado", "success")
+    return redirect(url_for("operadores.index"))
+
+
+@bp.get("/<int:op_id>/editar")
+def editar(op_id: int):
+    op = Operador.query.get_or_404(op_id)
+    return render_template("operadores/form.html", op=op)
+
+
+@bp.post("/<int:op_id>/actualizar")
+def actualizar(op_id: int):
+    op = Operador.query.get_or_404(op_id)
+    for key in ["nombre", "identificacion", "licencia", "puesto", "telefono", "status"]:
+        value = request.form.get(key)
+        if value is None or value == "":
+            continue
+        setattr(op, key, value)
+    db.session.commit()
+    flash("Operador actualizado", "success")
+    return redirect(url_for("operadores.index"))
+
+
+@bp.post("/<int:op_id>/eliminar")
+def eliminar(op_id: int):
+    op = Operador.query.get_or_404(op_id)
+    db.session.delete(op)
+    db.session.commit()
+    flash("Operador eliminado", "success")
+    return redirect(url_for("operadores.index"))
+
+
+@bp.get("/<int:op_id>")
+def detalle(op_id: int):
+    op = Operador.query.get_or_404(op_id)
+    return render_template("operadores/detalle.html", op=op)

--- a/app/cli.py
+++ b/app/cli.py
@@ -10,7 +10,7 @@ from flask import current_app
 from werkzeug.security import generate_password_hash
 
 from app.db import db
-from app.models import Equipo, User
+from app.models import Equipo, Operador, User
 from app.services.auth_service import ensure_admin_user
 from app.services.maintenance_service import cleanup_expired_refresh_tokens
 from app.utils.strings import normalize_email
@@ -135,5 +135,29 @@ def register_cli(app):
                 db.session.add(Equipo(**payload))
         db.session.commit()
         click.echo("Equipos seed: OK")
+
+    @app.cli.command("seed-operadores")
+    def seed_operadores():
+        """Cargar operadores de demostración si no existen."""
+
+        data = [
+            {
+                "nombre": "Juan Pérez",
+                "identificacion": "OP-001",
+                "puesto": "operador",
+                "licencia": "A",
+            },
+            {
+                "nombre": "María López",
+                "identificacion": "OP-002",
+                "puesto": "ayudante",
+                "licencia": "-",
+            },
+        ]
+        for payload in data:
+            if not Operador.query.filter_by(identificacion=payload.get("identificacion")).first():
+                db.session.add(Operador(**payload))
+        db.session.commit()
+        click.echo("Operadores seed: OK")
 
     return app

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -294,6 +294,7 @@ from app.models.asset import Asset  # noqa: E402,F401
 from app.models.equipo import Equipo  # noqa: E402,F401
 from app.models.folder import Folder  # noqa: E402,F401
 from app.models.invite import Invite  # noqa: E402,F401
+from app.models.operador import Operador  # noqa: E402,F401
 from app.models.refresh_token import RefreshToken  # noqa: E402,F401
 
 
@@ -310,6 +311,7 @@ __all__ = [
     "DailyChecklistItem",
     "Todo",
     "Equipo",
+    "Operador",
     "Invite",
     "RefreshToken",
     "User",

--- a/app/models/operador.py
+++ b/app/models/operador.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.db import db
+
+
+class Operador(db.Model):
+    __tablename__ = "operadores"
+
+    id = db.Column(db.Integer, primary_key=True)
+    nombre = db.Column(db.String(120), nullable=False, index=True)
+    identificacion = db.Column(db.String(64), unique=True)
+    licencia = db.Column(db.String(64))
+    puesto = db.Column(db.String(64))
+    telefono = db.Column(db.String(32))
+    status = db.Column(db.String(32), default="activo")
+    fecha_alta = db.Column(db.Date, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/app/registry.py
+++ b/app/registry.py
@@ -12,6 +12,7 @@ from app.blueprints.admin import bp_admin
 from app.blueprints.api.v1 import bp_api_v1
 from app.blueprints.auth import bp_auth
 from app.blueprints.equipos import bp as equipos_bp
+from app.blueprints.operadores import bp as operadores_bp
 from app.blueprints.ping import bp_ping
 from app.blueprints.web import bp_web
 from app.routes.assets import assets_bp
@@ -28,6 +29,7 @@ def register_blueprints(app: Flask) -> dict[str, Blueprint]:
         (bp_auth, {}),
         (bp_web, {}),
         (equipos_bp, {}),
+        (operadores_bp, {}),
         (bp_admin, {}),
         (bp_api_v1, {"url_prefix": "/api/v1"}),
         (todos_v1_bp, {}),

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,6 +27,9 @@
       <a class="btn btn-outline" href="{{ url_for('equipos.index') }}">
         <span>Equipos</span>
       </a>
+      <a class="btn btn-outline" href="{{ url_for('operadores.index') }}">
+        <span>Operadores</span>
+      </a>
       <div class="toolbar" style="margin-left:auto">
         {% if is_logged %}
           {% if current_role == "admin" %}

--- a/app/templates/operadores/detalle.html
+++ b/app/templates/operadores/detalle.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ op.nombre }}</h1>
+<ul>
+  <li>Identificación: {{ op.identificacion or '-' }}</li>
+  <li>Licencia: {{ op.licencia or '-' }}</li>
+  <li>Puesto: {{ op.puesto or '-' }}</li>
+  <li>Teléfono: {{ op.telefono or '-' }}</li>
+  <li>Status: {{ op.status }}</li>
+</ul>
+<a href="{{ url_for('operadores.editar', op_id=op.id) }}">Editar</a>
+{% endblock %}

--- a/app/templates/operadores/form.html
+++ b/app/templates/operadores/form.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>{{ 'Editar' if op else 'Nuevo' }} operador</h1>
+<form method="post" action="{{ url_for('operadores.actualizar', op_id=op.id) if op else url_for('operadores.crear') }}">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {% for name,label in [('nombre','Nombre'),('identificacion','Identificación'),('licencia','Licencia'),('puesto','Puesto'),('telefono','Teléfono'),('status','Status')] %}
+    <label>{{ label }} <input name="{{ name }}" value="{{ getattr(op, name, '') if op else '' }}"></label><br>
+  {% endfor %}
+  <button type="submit">Guardar</button>
+</form>
+{% endblock %}

--- a/app/templates/operadores/index.html
+++ b/app/templates/operadores/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Operadores</h1>
+<form method="get" class="mb-3">
+  <input name="q" value="{{ q }}" placeholder="Buscar por nombre / ID / puesto">
+  <button type="submit">Buscar</button>
+  <a href="{{ url_for('operadores.nuevo') }}">Nuevo</a>
+</form>
+<table>
+  <thead><tr><th>Nombre</th><th>ID</th><th>Puesto</th><th>Status</th><th></th></tr></thead>
+  <tbody>
+  {% for op in operadores %}
+    <tr>
+      <td><a href="{{ url_for('operadores.detalle', op_id=op.id) }}">{{ op.nombre }}</a></td>
+      <td>{{ op.identificacion or '-' }}</td>
+      <td>{{ op.puesto or '-' }}</td>
+      <td>{{ op.status }}</td>
+      <td>
+        <a href="{{ url_for('operadores.editar', op_id=op.id) }}">Editar</a>
+        <form action="{{ url_for('operadores.eliminar', op_id=op.id) }}" method="post" style="display:inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+        </form>
+      </td>
+    </tr>
+  {% else %}
+    <tr><td colspan="5">No hay operadores registrados.</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/migrations/versions/20251011_create_operadores_table.py
+++ b/migrations/versions/20251011_create_operadores_table.py
@@ -1,0 +1,55 @@
+"""create operadores table"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251011_create_operadores_table"
+down_revision = "20251010_create_equipos_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "operadores",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nombre", sa.String(length=120), nullable=False),
+        sa.Column("identificacion", sa.String(length=64), nullable=True),
+        sa.Column("licencia", sa.String(length=64), nullable=True),
+        sa.Column("puesto", sa.String(length=64), nullable=True),
+        sa.Column("telefono", sa.String(length=32), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=True,
+            server_default="activo",
+        ),
+        sa.Column(
+            "fecha_alta",
+            sa.Date(),
+            nullable=True,
+            server_default=sa.func.current_date(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("identificacion", name="uq_operadores_identificacion"),
+    )
+    op.create_index("ix_operadores_nombre", "operadores", ["nombre"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_operadores_nombre", table_name="operadores")
+    op.drop_table("operadores")


### PR DESCRIPTION
## Summary
- add the Operador model and Alembic migration for the operadores table
- expose CRUD views, templates, and navigation entry for managing operadores
- register a seed-operadores CLI command to populate demo records

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6243083d48326bd8612e4e61f6cbd