### PR TITLE
Link partes diarias with checklists

### DIFF
--- a/app/blueprints/partes/routes.py
+++ b/app/blueprints/partes/routes.py
@@ -89,11 +89,24 @@ def nuevo():
     equipos = Equipo.query.order_by(Equipo.codigo).all()
     operadores = Operador.query.order_by(Operador.nombre).all() if Operador else []
     hoy = date.today().isoformat()
+    pre = {
+        "fecha": request.args.get("fecha") or hoy,
+        "equipo_id": request.args.get("equipo_id"),
+        "operador_id": request.args.get("operador_id"),
+        "turno": request.args.get("turno") or "matutino",
+        "ubicacion": request.args.get("ubicacion"),
+        "clima": request.args.get("clima"),
+        "horas_inicio": request.args.get("horas_inicio"),
+        "horas_fin": request.args.get("horas_fin"),
+        "combustible_l": request.args.get("combustible_l"),
+        "observaciones": request.args.get("observaciones"),
+    }
     return render_template(
         "partes/nuevo.html",
         equipos=equipos,
         operadores=operadores,
         hoy=hoy,
+        pre=pre,
     )
 
 

--- a/app/models/parte_diaria.py
+++ b/app/models/parte_diaria.py
@@ -17,6 +17,12 @@ class ParteDiaria(db.Model):
         nullable=True,
         index=True,
     )
+    checklist_id = db.Column(
+        db.Integer,
+        db.ForeignKey("checklists.id"),
+        nullable=True,
+        index=True,
+    )
     turno = db.Column(db.String(16), nullable=False, default="matutino")
     ubicacion = db.Column(db.String(128))
     clima = db.Column(db.String(64))
@@ -35,6 +41,7 @@ class ParteDiaria(db.Model):
     )
     equipo = db.relationship("Equipo", back_populates="partes")
     operador = db.relationship("Operador", back_populates="partes")
+    checklist = db.relationship("Checklist", foreign_keys=[checklist_id])
 
     def calcular_horas_trabajadas(self) -> float | None:
         """Devuelve las horas trabajadas si hay horómetros válidos."""

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -62,6 +62,13 @@
   </header>
 
   <main class="container">
+    <nav>
+      <a href="{{ url_for('equipos.index') }}">Equipos</a> |
+      <a href="{{ url_for('operadores.index') }}">Operadores</a> |
+      <a href="{{ url_for('checklists.index') }}">Checklists</a> |
+      <a href="{{ url_for('partes.index') }}">Partes</a>
+    </nav>
+    <hr>
     {% if current_user.is_authenticated and (current_user.is_approved is defined) and not current_user.is_approved %}
       <div class="alert alert-warning" role="status">
         Tu cuenta aún no ha sido aprobada. Algunas secciones pueden estar bloqueadas.

--- a/app/templates/checklists/detalle.html
+++ b/app/templates/checklists/detalle.html
@@ -2,6 +2,17 @@
 {% block content %}
 <h1>{{ cl.template.name }} — {{ cl.date }} — <strong>{{ cl.overall_status }}</strong></h1>
 <p>
+  {% if parte %}
+    Vinculado a Parte <a href="{{ url_for('partes.detalle', parte_id=parte.id) }}">#{{ parte.id }}</a>
+    <a href="{{ url_for('partes.editar', parte_id=parte.id) }}">(editar)</a>
+  {% else %}
+    <form method="post" action="{{ url_for('checklists.generar_parte', cl_id=cl.id) }}" style="display:inline">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit">Generar Parte Diario</button>
+    </form>
+  {% endif %}
+</p>
+<p>
   Equipo: {{ cl.equipment.codigo if cl.equipment else cl.equipment_id }} |
   Turno: {{ cl.shift }} |
   Ubicación: {{ cl.location }} |

--- a/app/templates/partes/detalle.html
+++ b/app/templates/partes/detalle.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Parte — {{ p.fecha }} — Equipo {{ p.equipo.codigo if p.equipo else p.equipo_id }}</h1>
+{% if p.checklist_id %}
+  <p>Origen: Checklist <a href="{{ url_for('checklists.detalle', cl_id=p.checklist_id) }}">#{{ p.checklist_id }}</a></p>
+{% endif %}
 <p>Turno: {{ p.turno }} | Ubicación: {{ p.ubicacion or '-' }} | Clima: {{ p.clima or '-' }}</p>
 <p>
   Horas: {{ p.horas_inicio or '-' }} → {{ p.horas_fin or '-' }}

--- a/app/templates/partes/nuevo.html
+++ b/app/templates/partes/nuevo.html
@@ -3,12 +3,14 @@
 <h1>Nuevo parte diario</h1>
 <form method="post" action="{{ url_for('partes.crear') }}" class="form-grid">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-  <label>Fecha: <input type="date" name="fecha" value="{{ hoy }}"></label>
+  <label>Fecha: <input type="date" name="fecha" value="{{ pre.fecha if pre else hoy }}"></label>
   <label>Equipo:
     <select name="equipo_id" required>
       <option value="">— Seleccionar —</option>
       {% for e in equipos %}
-        <option value="{{ e.id }}">{{ e.codigo }} — {{ e.tipo }}</option>
+        <option value="{{ e.id }}" {{ 'selected' if pre.equipo_id and pre.equipo_id|int == e.id else '' }}>
+          {{ e.codigo }} — {{ e.tipo }}
+        </option>
       {% endfor %}
     </select>
   </label>
@@ -17,18 +19,18 @@
     <select name="operador_id">
       <option value="">—</option>
       {% for o in operadores %}
-        <option value="{{ o.id }}">{{ o.nombre }}</option>
+        <option value="{{ o.id }}" {{ 'selected' if pre.operador_id and pre.operador_id|int == o.id else '' }}>{{ o.nombre }}</option>
       {% endfor %}
     </select>
   </label>
   {% endif %}
-  <label>Turno: <input name="turno" value="matutino"></label>
-  <label>Ubicación: <input name="ubicacion"></label>
-  <label>Clima: <input name="clima"></label>
-  <label>Horas inicio: <input name="horas_inicio" type="number" step="0.1"></label>
-  <label>Horas fin: <input name="horas_fin" type="number" step="0.1"></label>
-  <label>Combustible (L): <input name="combustible_l" type="number" step="0.1"></label>
-  <label>Observaciones: <input name="observaciones"></label>
+  <label>Turno: <input name="turno" value="{{ pre.turno if pre else 'matutino' }}"></label>
+  <label>Ubicación: <input name="ubicacion" value="{{ pre.ubicacion or '' }}"></label>
+  <label>Clima: <input name="clima" value="{{ pre.clima or '' }}"></label>
+  <label>Horas inicio: <input name="horas_inicio" type="number" step="0.1" value="{{ pre.horas_inicio or '' }}"></label>
+  <label>Horas fin: <input name="horas_fin" type="number" step="0.1" value="{{ pre.horas_fin or '' }}"></label>
+  <label>Combustible (L): <input name="combustible_l" type="number" step="0.1" value="{{ pre.combustible_l or '' }}"></label>
+  <label>Observaciones: <input name="observaciones" value="{{ pre.observaciones or '' }}"></label>
   <button type="submit">Crear</button>
 </form>
 {% endblock %}

--- a/migrations/versions/20250926_add_checklist_fk_to_partes.py
+++ b/migrations/versions/20250926_add_checklist_fk_to_partes.py
@@ -1,0 +1,29 @@
+"""Add checklist foreign key to partes diarias"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "rev_20250926_partes_cl_fk"
+down_revision = "20251013_create_partes_diarias_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("partes_diarias") as b:
+        b.add_column(sa.Column("checklist_id", sa.Integer(), nullable=True))
+        b.create_index("ix_partes_diarias_checklist_id", ["checklist_id"])
+        b.create_foreign_key(
+            "fk_partes_checklist", "checklists", ["checklist_id"], ["id"]
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("partes_diarias") as b:
+        b.drop_constraint("fk_partes_checklist", type_="foreignkey")
+        b.drop_index("ix_partes_diarias_checklist_id")
+        b.drop_column("checklist_id")


### PR DESCRIPTION
## Summary
- add a nullable checklist foreign key on partes diarias and expose it on the model
- provide an Alembic migration plus UI/route hooks to create partes from checklists and display the linkage both ways
- prefill new parte forms from query parameters and add a simple navigation bar across key sections

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d63c03da688326b1e5fa3463879aaf