### PR TITLE
Add dashboard homepage with KPI cards and alerts

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -187,6 +187,10 @@ def create_app(config_name: str | None = None) -> Flask:
 
     app.register_blueprint(partes_bp)
 
+    from app.blueprints.dashboard import bp as dashboard_bp
+
+    app.register_blueprint(dashboard_bp)
+
     # Exentamos la API pública JSON del CSRF global
     api_v1_bp = blueprints.get("api_v1")
     if api_v1_bp is not None:

--- a/app/blueprints/dashboard/__init__.py
+++ b/app/blueprints/dashboard/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from flask import Blueprint
+
+bp = Blueprint("dashboard", __name__, url_prefix="")
+
+from . import routes  # noqa: E402,F401

--- a/app/blueprints/dashboard/routes.py
+++ b/app/blueprints/dashboard/routes.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from flask import render_template
+from sqlalchemy import func
+
+from app import db
+from app.models import Checklist, Equipo, ParteDiaria
+
+try:
+    from app.models import Operador
+except Exception:  # pragma: no cover - apps sin operadores
+    Operador = None
+
+from . import bp
+
+
+@bp.get("/")
+def home():
+    hoy = date.today()
+    # KPIs
+    total_equipos = db.session.scalar(db.select(func.count()).select_from(Equipo))
+    total_operadores = (
+        db.session.scalar(db.select(func.count()).select_from(Operador)) if Operador else 0
+    )
+
+    # Partes de hoy
+    q_partes_hoy = db.select(
+        func.count(ParteDiaria.id),
+        func.coalesce(func.sum(ParteDiaria.horas_trabajadas), 0.0),
+        func.coalesce(func.sum(ParteDiaria.combustible_l), 0.0),
+    ).where(ParteDiaria.fecha == hoy)
+    partes_count, horas_hoy, comb_hoy = db.session.execute(q_partes_hoy).one()
+
+    # Checklists de hoy
+    q_chk_apto = db.select(func.count(Checklist.id)).where(
+        Checklist.date == hoy, Checklist.overall_status == "APTO"
+    )
+    q_chk_no = db.select(func.count(Checklist.id)).where(
+        Checklist.date == hoy, Checklist.overall_status == "NO_APTO"
+    )
+    chk_apto = db.session.scalar(q_chk_apto)
+    chk_noapto = db.session.scalar(q_chk_no)
+
+    # Alertas: NO_APTO últimos 3 días
+    desde = hoy - timedelta(days=3)
+    noaptos = (
+        db.session.query(Checklist)
+        .filter(Checklist.date >= desde, Checklist.overall_status == "NO_APTO")
+        .order_by(Checklist.date.desc())
+        .limit(10)
+        .all()
+    )
+
+    # Partes de hoy con datos faltantes
+    partes_incompletos = (
+        db.session.query(ParteDiaria)
+        .filter(ParteDiaria.fecha == hoy)
+        .filter((ParteDiaria.horas_trabajadas.is_(None)) | (ParteDiaria.combustible_l.is_(None)))
+        .order_by(ParteDiaria.id.desc())
+        .all()
+    )
+
+    return render_template(
+        "dashboard/index.html",
+        total_equipos=total_equipos,
+        total_operadores=total_operadores,
+        partes_count=partes_count,
+        horas_hoy=horas_hoy,
+        comb_hoy=comb_hoy,
+        chk_apto=chk_apto,
+        chk_noapto=chk_noapto,
+        noaptos=noaptos,
+        partes_incompletos=partes_incompletos,
+        hoy=hoy,
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -63,6 +63,7 @@
 
   <main class="container">
     <nav>
+      <a href="{{ url_for('dashboard.home') }}">Inicio</a> |
       <a href="{{ url_for('equipos.index') }}">Equipos</a> |
       <a href="{{ url_for('operadores.index') }}">Operadores</a> |
       <a href="{{ url_for('checklists.index') }}">Checklists</a> |

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Dashboard</h1>
+
+<!-- Atajos -->
+<p>
+  <a href="{{ url_for('checklists.nuevo') }}">➕ Nuevo Checklist</a> |
+  <a href="{{ url_for('partes.nuevo') }}">➕ Nuevo Parte</a> |
+  <a href="{{ url_for('equipos.nuevo') }}">➕ Nuevo Equipo</a>
+  {% if total_operadores is not none %}| <a href="{{ url_for('operadores.nuevo') }}">➕ Nuevo Operador</a>{% endif %}
+</p>
+
+<!-- KPIs -->
+<div style="display:flex; gap:16px; flex-wrap:wrap;">
+  <div style="border:1px solid #ddd; padding:12px; border-radius:8px; min-width:180px;">
+    <div>Total Equipos</div>
+    <h2>{{ total_equipos }}</h2>
+  </div>
+  <div style="border:1px solid #ddd; padding:12px; border-radius:8px; min-width:180px;">
+    <div>Total Operadores</div>
+    <h2>{{ total_operadores }}</h2>
+  </div>
+  <div style="border:1px solid #ddd; padding:12px; border-radius:8px; min-width:220px;">
+    <div>Partes de hoy ({{ hoy }})</div>
+    <h2>{{ partes_count }}</h2>
+    <small>Horas: {{ '%.2f'|format(horas_hoy) }} &nbsp;•&nbsp; Comb: {{ '%.2f'|format(comb_hoy) }} L</small>
+  </div>
+  <div style="border:1px solid #ddd; padding:12px; border-radius:8px; min-width:220px;">
+    <div>Checklists de hoy ({{ hoy }})</div>
+    <h2>APTO {{ chk_apto }} / NO_APTO {{ chk_noapto }}</h2>
+  </div>
+</div>
+
+<!-- Alertas -->
+<h2 style="margin-top:24px;">Alertas</h2>
+<div style="display:flex; gap:16px; flex-wrap:wrap;">
+  <div style="border:1px solid #f2c; padding:12px; border-radius:8px; min-width:300px;">
+    <h3 style="margin:0 0 8px 0;">NO_APTO (últimos 3 días)</h3>
+    {% if noaptos %}
+    <ul>
+      {% for c in noaptos %}
+        <li>
+          {{ c.date }} — {{ c.template.name }} — <b>{{ c.overall_status }}</b>
+          <a href="{{ url_for('checklists.detalle', cl_id=c.id) }}">ver</a>
+        </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p>Sin NO_APTO recientes 🎉</p>
+    {% endif %}
+  </div>
+
+  <div style="border:1px solid #fc6; padding:12px; border-radius:8px; min-width:300px;">
+    <h3 style="margin:0 0 8px 0;">Partes de hoy incompletos</h3>
+    {% if partes_incompletos %}
+    <ul>
+      {% for p in partes_incompletos %}
+        <li>
+          Parte #{{ p.id }} — Equipo {{ p.equipo_id }}
+          {% if p.horas_trabajadas is none %} • falta <b>horas</b>{% endif %}
+          {% if p.combustible_l is none %} • falta <b>combustible</b>{% endif %}
+          <a href="{{ url_for('partes.editar', parte_id=p.id) }}">editar</a>
+        </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p>Todos los partes de hoy están completos ✅</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a dashboard blueprint with a homepage route that aggregates KPI totals, daily checklists, and alerts
- create a dashboard template showing KPI cards, quick links, and alerts for recent NO_APTO checklists and incomplete partes
- expose the dashboard from the main navigation and register the blueprint with the application factory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63f755bb4832694b3f02f1a6a308f