### PR TITLE
Fix checklist enum type creation

### DIFF
--- a/app/models/checklist.py
+++ b/app/models/checklist.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 
+from sqlalchemy.dialects.postgresql import ENUM as PGEnum
+
 from app.db import db
 
 
@@ -69,7 +71,9 @@ class ChecklistAnswer(db.Model):
     checklist_id = db.Column(db.Integer, db.ForeignKey("checklists.id"), nullable=False)
     item_id = db.Column(db.Integer, db.ForeignKey("cl_items.id"), nullable=False)
     result = db.Column(
-        db.Enum(AnswerEnum, name="answerenum"), nullable=False, default=AnswerEnum.OK
+        PGEnum("OK", "FAIL", "NA", name="answerenum", create_type=False),
+        nullable=False,
+        default="OK",
     )
     note = db.Column(db.String(255))
     photo_path = db.Column(db.String(255))

--- a/migrations/versions/20251012_create_checklists_tables.py
+++ b/migrations/versions/20251012_create_checklists_tables.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 
 revision = "20251012_create_checklists_tables"
@@ -11,12 +12,12 @@ down_revision = "20251011_create_operadores_table"
 branch_labels = None
 depends_on = None
 
-answer_enum = sa.Enum("OK", "FAIL", "NA", name="answerenum")
-
-
 def upgrade() -> None:
-    bind = op.get_bind()
-    answer_enum.create(bind, checkfirst=True)
+    # Crear el tipo ENUM si no existe
+    answer_enum = postgresql.ENUM(
+        "OK", "FAIL", "NA", name="answerenum", create_type=False
+    )
+    answer_enum.create(op.get_bind(), checkfirst=True)
 
     op.create_table(
         "cl_templates",
@@ -66,9 +67,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    answer_enum = postgresql.ENUM(
+        "OK", "FAIL", "NA", name="answerenum", create_type=False
+    )
     op.drop_table("cl_answers")
     op.drop_table("checklists")
     op.drop_table("cl_items")
     op.drop_table("cl_templates")
-    bind = op.get_bind()
-    answer_enum.drop(bind, checkfirst=True)
+    answer_enum.drop(op.get_bind(), checkfirst=True)


### PR DESCRIPTION
## Summary
- create the checklist answer enum using the PostgreSQL dialect with explicit create/drop
- reuse the shared enum object when creating checklist tables
- align the SQLAlchemy model with the shared PostgreSQL enum definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64235d8448326b6df5c30c4d709da