### PR TITLE
Shorten migration revision IDs and restore pre-deploy guard

### DIFF
--- a/migrations/versions/20251011_create_operadores_table.py
+++ b/migrations/versions/20251011_create_operadores_table.py
@@ -6,8 +6,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "20251011_create_operadores_table"
-down_revision = "20251010_create_equipos_table"
+revision = "rev_20251011_operadores"
+down_revision = "rev_20250924_refresh_tokens"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/20251012_create_checklists_tables.py
+++ b/migrations/versions/20251012_create_checklists_tables.py
@@ -7,8 +7,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 
-revision = "20251012_create_checklists_tables"
-down_revision = "20251011_create_operadores_table"
+revision = "rev_20251012_checklists"
+down_revision = "rev_20251011_operadores"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/20251013_create_partes_diarias_tables.py
+++ b/migrations/versions/20251013_create_partes_diarias_tables.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision = "20251013_create_partes_diarias_tables"
-down_revision = "20251012_create_checklists_tables"
+down_revision = "rev_20251012_checklists"
 branch_labels = None
 depends_on = None
 

--- a/render.yaml
+++ b/render.yaml
@@ -3,15 +3,7 @@ services:
     name: proyecto-codex
     env: python
     buildCommand: pip install -r requirements.txt
-    preDeployCommand: |
-      python - <<'PY'
-      import os, psycopg
-      with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
-          with conn.cursor() as cur:
-              cur.execute("ALTER TABLE IF EXISTS alembic_version ALTER COLUMN version_num TYPE VARCHAR(64);")
-          conn.commit()
-      PY
-      alembic -c migrations/alembic.ini upgrade head && FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
+    preDeployCommand: python -c "import os,psycopg; conn=psycopg.connect(os.environ['DATABASE_URL']); cur=conn.cursor(); cur.execute('ALTER TABLE IF EXISTS alembic_version ALTER COLUMN version_num TYPE VARCHAR(64);'); conn.commit(); cur.close(); conn.close()" && alembic -c migrations/alembic.ini upgrade head && FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
     startCommand: gunicorn -w 3 wsgi:app
     healthCheckPath: /healthz
     envVars:


### PR DESCRIPTION
## Summary
- shorten the revision identifiers for the operadores and checklists migrations and update downstream dependency
- restore the render pre-deploy command to widen alembic_version.version_num before upgrades

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64550e11883268886cf5dea430f54