### PR TITLE
Fix checklist FK migration lineage

### DIFF
--- a/migrations/versions/20250926_add_checklist_fk_to_partes.py
+++ b/migrations/versions/20250926_add_checklist_fk_to_partes.py
@@ -8,7 +8,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "rev_20250926_partes_cl_fk"
-down_revision = "20251013_create_partes_diarias_tables"
+down_revision = "rev_20251012_checklists"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- update the checklist foreign key migration to depend on the checklists migration, ensuring a linear history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6484699c88326b6ed30a217426aef