### PR TITLE
Fix Render predeploy and merge Alembic branches

### DIFF
--- a/migrations/versions/20251011_create_operadores_table.py
+++ b/migrations/versions/20251011_create_operadores_table.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision = "rev_20251011_operadores"
-down_revision = "rev_20250924_refresh_tokens"
+down_revision = "20251010_create_equipos_table"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/rev_20251013_merge_heads.py
+++ b/migrations/versions/rev_20251013_merge_heads.py
@@ -1,0 +1,20 @@
+"""merge heads for checklist branches"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "rev_20251013_merge_heads"
+down_revision = ("rev_20250926_partes_cl_fk", "20251013_create_partes_diarias_tables")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,10 @@ services:
     name: proyecto-codex
     env: python
     buildCommand: pip install -r requirements.txt
-    preDeployCommand: python -c "import os,psycopg; conn=psycopg.connect(os.environ['DATABASE_URL']); cur=conn.cursor(); cur.execute('ALTER TABLE IF EXISTS alembic_version ALTER COLUMN version_num TYPE VARCHAR(64);'); conn.commit(); cur.close(); conn.close()" && alembic -c migrations/alembic.ini upgrade head && FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
+    preDeployCommand: >
+      python -c "import os,psycopg; conn=psycopg.connect(os.environ['DATABASE_URL']); cur=conn.cursor(); cur.execute('ALTER TABLE IF EXISTS alembic_version ALTER COLUMN version_num TYPE VARCHAR(64);'); conn.commit(); cur.close(); conn.close()" &&
+      alembic -c migrations/alembic.ini upgrade heads &&
+      FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
     startCommand: gunicorn -w 3 wsgi:app
     healthCheckPath: /healthz
     envVars:


### PR DESCRIPTION
## Summary
- update Render pre-deploy script to run `alembic upgrade heads` so every branch is applied during deploys
- add a merge migration to reconcile the checklist-related heads and make the operadores migration depend on the equipos table

## Testing
- alembic -c migrations/alembic.ini heads

------
https://chatgpt.com/codex/tasks/task_e_68d64b24ec48832685e02bd13d3716c1