### PR TITLE
Fix operadores revision id

### DIFF
--- a/migrations/versions/20251011_create_operadores_table.py
+++ b/migrations/versions/20251011_create_operadores_table.py
@@ -6,7 +6,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "rev_20251011_operadores"
+revision = "20251011_create_operadores_table"
 down_revision = "20251010_create_equipos_table"
 branch_labels = None
 depends_on = None

--- a/migrations/versions/20251012_create_checklists_tables.py
+++ b/migrations/versions/20251012_create_checklists_tables.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects import postgresql
 
 
 revision = "rev_20251012_checklists"
-down_revision = "rev_20251011_operadores"
+down_revision = "20251011_create_operadores_table"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- align the operadores migration revision identifier with its filename
- update the checklists migration to depend on the corrected revision id

## Testing
- alembic -c migrations/alembic.ini history --verbose | tail -n 40

------
https://chatgpt.com/codex/tasks/task_e_68d79f5e6b68832696874f62a0798b32