### PR TITLE
Refine Render deployment configuration

### DIFF
--- a/migrations/versions/20251013_rev_pdiarias.py
+++ b/migrations/versions/20251013_rev_pdiarias.py
@@ -6,7 +6,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "20251013_create_partes_diarias_tables"
+revision = "rev_20251013_pdiarias"
 down_revision = "rev_20251012_checklists"
 branch_labels = None
 depends_on = None

--- a/migrations/versions/rev_20251013_merge_heads.py
+++ b/migrations/versions/rev_20251013_merge_heads.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 
 
 revision = "rev_20251013_merge_heads"
-down_revision = ("rev_20250926_partes_cl_fk", "20251013_create_partes_diarias_tables")
+down_revision = ("rev_20250926_partes_cl_fk", "rev_20251013_pdiarias")
 branch_labels = None
 depends_on = None
 

--- a/render.yaml
+++ b/render.yaml
@@ -3,11 +3,24 @@ services:
     name: proyecto-codex
     env: python
     buildCommand: pip install -r requirements.txt
-    preDeployCommand: >
-      python -c "import os,psycopg; conn=psycopg.connect(os.environ['DATABASE_URL']); cur=conn.cursor(); cur.execute('ALTER TABLE IF EXISTS alembic_version ALTER COLUMN version_num TYPE VARCHAR(64);'); conn.commit(); cur.close(); conn.close()" &&
-      alembic -c migrations/alembic.ini upgrade heads &&
-      FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
-    startCommand: gunicorn -w 3 wsgi:app
+    preDeployCommand: |
+      python - <<'PY'
+      import os
+      from sqlalchemy import create_engine, text
+
+      engine = create_engine(os.environ["DATABASE_URL"])
+      with engine.begin() as conn:
+          conn.execute(
+              text(
+                  "ALTER TABLE IF EXISTS alembic_version "
+                  "ALTER COLUMN version_num TYPE VARCHAR(128)"
+              )
+          )
+          print("OK: alembic_version.version_num = VARCHAR(128)")
+      PY
+      && alembic -c migrations/alembic.ini upgrade head
+      && FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
+    startCommand: gunicorn -w 2 -k gthread -t 120 -b 0.0.0.0:$PORT 'app:create_app()'
     healthCheckPath: /healthz
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Summary
- update the Render pre-deploy workflow to expand the alembic_version column to 128 characters via SQLAlchemy before running migrations and seeding
- align the Render start command with the threaded gunicorn invocation used in production
- shorten the partes diarias migration revision id and update dependent merge head metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7a42b4b788326b7f8f65039601ccb