### PR TITLE
Add helper to ensure unique usernames when seeding admin users

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -37,50 +37,13 @@ def users():
 def ensure_admin(email: str, password: str) -> None:
     """Crear o actualizar un administrador con las credenciales dadas."""
 
-    email = normalize_email(email)
-    if not email:
+    try:
+        user = ensure_admin_user(email=email, password=password)
+    except ValueError:
         click.echo("Email inválido", err=True)
         raise SystemExit(1)
 
-    user = User.query.filter_by(email=email).first()
-    if not user:
-        base_username = (email.split("@", 1)[0] or "admin").strip() or "admin"
-        candidate = base_username
-        counter = 1
-        while User.query.filter_by(username=candidate).first():
-            counter += 1
-            candidate = f"{base_username}{counter}"
-        user = User(
-            email=email,
-            username=candidate,
-            role="admin",
-            is_admin=True,
-            is_active=True,
-            status="approved",
-            is_approved=True,
-            approved_at=datetime.now(timezone.utc),
-        )
-        db.session.add(user)
-    else:
-        user.role = "admin"
-        user.is_admin = True
-        user.is_active = True
-        if not getattr(user, "approved_at", None):
-            user.approved_at = datetime.now(timezone.utc)
-        try:
-            user.status = "approved"
-        except Exception:
-            pass
-        if hasattr(user, "is_approved"):
-            user.is_approved = True
-
-    if hasattr(user, "set_password"):
-        user.set_password(password)
-    else:
-        user.password_hash = generate_password_hash(password)
-
-    db.session.commit()
-    click.echo("Admin listo")
+    click.echo(f"Admin listo: {user.email}")
 
 
 def register_cli(app):


### PR DESCRIPTION
## Summary
- reuse the shared ensure_admin_user service from the CLI ensure-admin command
- ensure automatic admin user creation generates unique usernames when needed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8054d971c832691857eeed5e72fba