### PR TITLE
Ensure local admin script can run against sqlite

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -105,7 +105,12 @@ class User(db.Model, UserMixin):
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
     email: Mapped[str] = mapped_column(String(254), unique=True, nullable=False, index=True)
-    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_hash: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        default="",
+        server_default="",
+    )
     role: Mapped[str] = mapped_column(
         String(20),
         nullable=False,


### PR DESCRIPTION
## Summary
- fall back to the development configuration when no production database URL is provided locally
- default the SQLite database path to the instance directory so CLI commands and scripts share the same file
- give the User.password_hash column a safe default so helper scripts can create an admin user before assigning a password

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d88803d84c83268ec5f0b059a2b157