### PR TITLE
Add DISABLE_SECURITY development bypass flag

### DIFF
--- a/app/auth/roles.py
+++ b/app/auth/roles.py
@@ -43,6 +43,10 @@ def role_required(*allowed_roles: str):
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
+            if current_app.config.get("LOGIN_DISABLED") or current_app.config.get(
+                "WTF_CSRF_ENABLED"
+            ) is False:
+                return fn(*args, **kwargs)
             if current_app.config.get("AUTH_SIMPLE", False):
                 role = _resolve_role_from_session()
                 if role is None:

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from flask_bcrypt import Bcrypt
 from flask_login import LoginManager
 from flask_limiter import Limiter
@@ -25,4 +27,5 @@ def init_auth_extensions(app):
     """Inicializa las extensiones relacionadas con autenticación."""
     bcrypt.init_app(app)
     login_manager.init_app(app)
-    csrf.init_app(app)
+    if os.getenv("DISABLE_SECURITY") != "1" and app.config.get("WTF_CSRF_ENABLED", True):
+        csrf.init_app(app)


### PR DESCRIPTION
## Summary
- add a DISABLE_SECURITY switch in create_app to disable auth, CSRF, and limiter for development
- ensure extensions respect the security toggle and skip CSRF initialization when disabled
- allow role_required decorator to bypass checks when security is turned off

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8a5eb7a4c8326b4c0e28a9b3059e4