### PR TITLE
Enable optional security bypass in dev

### DIFF
--- a/app/auth/roles.py
+++ b/app/auth/roles.py
@@ -43,9 +43,9 @@ def role_required(*allowed_roles: str):
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            if current_app.config.get("LOGIN_DISABLED") or current_app.config.get(
-                "WTF_CSRF_ENABLED"
-            ) is False:
+            if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
+                "LOGIN_DISABLED"
+            ):
                 return fn(*args, **kwargs)
             if current_app.config.get("AUTH_SIMPLE", False):
                 role = _resolve_role_from_session()

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import os
-
 from flask_bcrypt import Bcrypt
 from flask_login import LoginManager
 from flask_limiter import Limiter
@@ -26,6 +24,3 @@ limiter = Limiter(key_func=get_remote_address, headers_enabled=True, default_lim
 def init_auth_extensions(app):
     """Inicializa las extensiones relacionadas con autenticación."""
     bcrypt.init_app(app)
-    login_manager.init_app(app)
-    if os.getenv("DISABLE_SECURITY") != "1" and app.config.get("WTF_CSRF_ENABLED", True):
-        csrf.init_app(app)

--- a/app/security/__init__.py
+++ b/app/security/__init__.py
@@ -29,6 +29,10 @@ def require_login(bp, exclude: Iterable[str] | None = None) -> None:
 
     @bp.before_request
     def _guard():  # type: ignore[func-returns-value]
+        if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
+            "LOGIN_DISABLED"
+        ):
+            return None
         endpoint = (request.endpoint or "").split(".")[-1]
         if endpoint in exclude_set:
             return None


### PR DESCRIPTION
## Summary
- allow create_app to disable login, csrf, and rate limiting when the DISABLE_SECURITY flag is set, including providing a dev user and initializing extensions safely
- bypass custom role and login guards when security is disabled and streamline auth extension setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8ae0095388326aae976fec853cb57