### PR TITLE
Add dev mode banner when security disabled

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -209,6 +209,17 @@ def create_app(config_name: str | None = None) -> Flask:
             "pending_users_count": pending_count,
         }
 
+    @app.context_processor
+    def inject_dev_mode_flag():
+        from flask import current_app
+
+        return {
+            "DEV_MODE": bool(
+                current_app.config.get("SECURITY_DISABLED")
+                or current_app.config.get("LOGIN_DISABLED")
+            )
+        }
+
     # Blueprints
     from . import models  # noqa: F401
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,9 +5,26 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>{% block title %}SGC — Obra de Dragado{% endblock %}</title>
+  {% if DEV_MODE %}
+  <meta name="robots" content="noindex,nofollow">
+  {% endif %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body>
+  {% if DEV_MODE %}
+  <div class="dev-banner">DEV MODE — security disabled</div>
+  <style>
+    .dev-banner{
+      position:fixed; top:0; left:0; right:0;
+      background:#FBBF24; color:#111;
+      font:600 14px/1.1 system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      text-align:center; padding:8px 10px; z-index:9999;
+      box-shadow:0 1px 3px rgba(0,0,0,.2)
+    }
+    /* Evita que el banner tape el contenido */
+    body { padding-top: 44px; }
+  </style>
+  {% endif %}
   <header class="navbar">
     <div class="nav-left">
       <span class="brand">


### PR DESCRIPTION
## Summary
- expose a DEV_MODE context variable based on security flags
- show a fixed banner and dev-only robots meta when security is disabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c0512e6c83269b6fa91f1891502e