### PR TITLE
Allow security bypass when DISABLE_SECURITY=1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -78,6 +78,7 @@ def create_app(config_name: str | None = None) -> Flask:
         app.config["LOGIN_DISABLED"] = True
         app.config["WTF_CSRF_ENABLED"] = False
         app.config["RATELIMIT_ENABLED"] = False
+        app.config["JWT_COOKIE_CSRF_PROTECT"] = False
 
         class DevUser(AnonymousUserMixin):
             id = 0
@@ -102,6 +103,13 @@ def create_app(config_name: str | None = None) -> Flask:
             from app.extensions import login_manager
 
             login_manager.anonymous_user = DevUser
+        except Exception:
+            pass
+
+        try:
+            from flask_cors import CORS
+
+            CORS(app, supports_credentials=True)
         except Exception:
             pass
     # ======= FIN DEV MODE =======

--- a/app/authz.py
+++ b/app/authz.py
@@ -85,6 +85,10 @@ def _roles_for_entity(entity: Any) -> set[str]:
 def login_required(view: F) -> F:
     @wraps(view)
     def wrapped(*args: Any, **kwargs: Any):
+        if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
+            "LOGIN_DISABLED"
+        ):
+            return view(*args, **kwargs)
         if current_app.config.get("AUTH_SIMPLE", True):
             return view(*args, **kwargs)
         if session.get("user"):
@@ -105,6 +109,11 @@ def requires_role(*required_roles: str) -> Callable[[F], F]:
         @wraps(view)
         def wrapped(*args: Any, **kwargs: Any):
             if not normalized:
+                return view(*args, **kwargs)
+
+            if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
+                "LOGIN_DISABLED"
+            ):
                 return view(*args, **kwargs)
 
             current_roles = _resolve_roles(_current_role())

--- a/app/blueprints/auth/routes.py
+++ b/app/blueprints/auth/routes.py
@@ -206,6 +206,10 @@ def login_post():
 
 @bp_auth.before_app_request
 def _enforce_force_change_password():
+    if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
+        "LOGIN_DISABLED"
+    ):
+        return None
     allowed = {"auth.logout", "auth.change_password", "static"}
     if (
         current_user.is_authenticated

--- a/app/security_jwt.py
+++ b/app/security_jwt.py
@@ -1,0 +1,27 @@
+"""Compatibilidad con flask-jwt-extended en modo DEV.
+
+Este módulo expone ``jwt_required`` de forma perezosa para que, cuando la
+bandera ``DISABLE_SECURITY=1`` esté activa, cualquier decoración con
+``@jwt_required`` se convierta en un no-op. En otros entornos simplemente se
+reexporta el decorador real desde ``flask_jwt_extended``.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+if os.getenv("DISABLE_SECURITY") == "1":
+
+    def jwt_required(*_args, **_kwargs):  # type: ignore[unused-argument]
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+
+else:  # pragma: no cover - import opcional
+    from flask_jwt_extended import jwt_required  # type: ignore[misc]  # noqa: F401
+
+
+__all__ = ["jwt_required"]

--- a/app/templates/checklists/detalle.html
+++ b/app/templates/checklists/detalle.html
@@ -4,14 +4,21 @@
 <p>
   {% if parte %}
     Vinculado a Parte <a href="{{ url_for('partes.detalle', parte_id=parte.id) }}">#{{ parte.id }}</a>
-    <a href="{{ url_for('partes.editar', parte_id=parte.id) }}">(editar)</a>
+    {% if DEV_MODE %}<a href="{{ url_for('partes.editar', parte_id=parte.id) }}">(editar)</a>{% endif %}
   {% else %}
+    {% if DEV_MODE %}
     <form method="post" action="{{ url_for('checklists.generar_parte', cl_id=cl.id) }}" style="display:inline">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <button type="submit">Generar Parte Diario</button>
     </form>
+    {% endif %}
   {% endif %}
 </p>
+{% if DEV_MODE %}
+<p>
+  <a href="{{ url_for('checklists.editar', cl_id=cl.id) }}">Editar checklist</a>
+</p>
+{% endif %}
 <p>
   Equipo: {{ cl.equipment.codigo if cl.equipment else cl.equipment_id }} |
   Turno: {{ cl.shift }} |

--- a/app/templates/checklists/index.html
+++ b/app/templates/checklists/index.html
@@ -4,7 +4,9 @@
 <form method="get" class="mb-2">
   <input name="q" value="{{ q }}" placeholder="Buscar por equipo...">
   <button type="submit">Buscar</button>
+  {% if DEV_MODE %}
   <a class="btn" href="{{ url_for('checklists.nuevo') }}">Nuevo</a>
+  {% endif %}
 </form>
 <table>
   <thead>
@@ -13,7 +15,7 @@
       <th>Equipo</th>
       <th>Plantilla</th>
       <th>Estatus</th>
-      <th></th>
+      <th>Acciones</th>
     </tr>
   </thead>
   <tbody>
@@ -23,7 +25,12 @@
       <td>{{ r.equipment.codigo if r.equipment else r.equipment_id }}</td>
       <td>{{ r.template.name if r.template else '-' }}</td>
       <td><strong>{{ r.overall_status }}</strong></td>
-      <td><a href="{{ url_for('checklists.detalle', cl_id=r.id) }}">Ver</a></td>
+      <td>
+        <a href="{{ url_for('checklists.detalle', cl_id=r.id) }}">Ver</a>
+        {% if DEV_MODE %}
+          <a href="{{ url_for('checklists.editar', cl_id=r.id) }}">Editar</a>
+        {% endif %}
+      </td>
     </tr>
   {% else %}
     <tr><td colspan="5">Sin registros</td></tr>

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -3,12 +3,14 @@
 <h1>Dashboard</h1>
 
 <!-- Atajos -->
+{% if DEV_MODE %}
 <p>
   <a href="{{ url_for('checklists.nuevo') }}">➕ Nuevo Checklist</a> |
   <a href="{{ url_for('partes.nuevo') }}">➕ Nuevo Parte</a> |
   <a href="{{ url_for('equipos.nuevo') }}">➕ Nuevo Equipo</a>
   {% if total_operadores is not none %}| <a href="{{ url_for('operadores.nuevo') }}">➕ Nuevo Operador</a>{% endif %}
 </p>
+{% endif %}
 
 <!-- KPIs -->
 <div style="display:flex; gap:16px; flex-wrap:wrap;">
@@ -59,7 +61,7 @@
           Parte #{{ p.id }} — Equipo {{ p.equipo_id }}
           {% if p.horas_trabajadas is none %} • falta <b>horas</b>{% endif %}
           {% if p.combustible_l is none %} • falta <b>combustible</b>{% endif %}
-          <a href="{{ url_for('partes.editar', parte_id=p.id) }}">editar</a>
+          {% if DEV_MODE %}<a href="{{ url_for('partes.editar', parte_id=p.id) }}">editar</a>{% endif %}
         </li>
       {% endfor %}
     </ul>

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -10,5 +10,7 @@
   <li>Ubicación: {{ equipo.ubicacion or '-' }}</li>
   <li>Horas de uso: {{ equipo.horas_uso }}</li>
 </ul>
+{% if DEV_MODE %}
 <a href="{{ url_for('equipos.editar', equipo_id=equipo.id) }}">Editar</a>
+{% endif %}
 {% endblock %}

--- a/app/templates/equipos/index.html
+++ b/app/templates/equipos/index.html
@@ -4,15 +4,23 @@
 <form method="get" class="mb-3">
   <input name="q" value="{{ q }}" placeholder="Buscar por código / tipo / marca">
   <button type="submit">Buscar</button>
+  {% if DEV_MODE %}
   <a href="{{ url_for('equipos.nuevo') }}">Nuevo</a>
+  {% endif %}
 </form>
 <table>
-  <thead><tr><th>Código</th><th>Tipo</th><th>Marca</th><th>Status</th><th></th></tr></thead>
+  <thead>
+    <tr>
+      <th>Código</th><th>Tipo</th><th>Marca</th><th>Status</th>
+      {% if DEV_MODE %}<th></th>{% endif %}
+    </tr>
+  </thead>
   <tbody>
   {% for equipo in equipos %}
     <tr>
       <td><a href="{{ url_for('equipos.detalle', equipo_id=equipo.id) }}">{{ equipo.codigo }}</a></td>
       <td>{{ equipo.tipo }}</td><td>{{ equipo.marca or '-' }}</td><td>{{ equipo.status }}</td>
+      {% if DEV_MODE %}
       <td>
         <a href="{{ url_for('equipos.editar', equipo_id=equipo.id) }}">Editar</a>
         <form action="{{ url_for('equipos.eliminar', equipo_id=equipo.id) }}" method="post" style="display:inline">
@@ -20,9 +28,10 @@
           <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
         </form>
       </td>
+      {% endif %}
     </tr>
   {% else %}
-    <tr><td colspan="5">No hay equipos registrados.</td></tr>
+    <tr><td colspan="{{ 5 if DEV_MODE else 4 }}">No hay equipos registrados.</td></tr>
   {% endfor %}
   </tbody>
 </table>

--- a/app/templates/operadores/detalle.html
+++ b/app/templates/operadores/detalle.html
@@ -8,5 +8,7 @@
   <li>Teléfono: {{ op.telefono or '-' }}</li>
   <li>Status: {{ op.status }}</li>
 </ul>
+{% if DEV_MODE %}
 <a href="{{ url_for('operadores.editar', op_id=op.id) }}">Editar</a>
+{% endif %}
 {% endblock %}

--- a/app/templates/operadores/index.html
+++ b/app/templates/operadores/index.html
@@ -4,10 +4,17 @@
 <form method="get" class="mb-3">
   <input name="q" value="{{ q }}" placeholder="Buscar por nombre / ID / puesto">
   <button type="submit">Buscar</button>
+  {% if DEV_MODE %}
   <a href="{{ url_for('operadores.nuevo') }}">Nuevo</a>
+  {% endif %}
 </form>
 <table>
-  <thead><tr><th>Nombre</th><th>ID</th><th>Puesto</th><th>Status</th><th></th></tr></thead>
+  <thead>
+    <tr>
+      <th>Nombre</th><th>ID</th><th>Puesto</th><th>Status</th>
+      {% if DEV_MODE %}<th></th>{% endif %}
+    </tr>
+  </thead>
   <tbody>
   {% for op in operadores %}
     <tr>
@@ -15,6 +22,7 @@
       <td>{{ op.identificacion or '-' }}</td>
       <td>{{ op.puesto or '-' }}</td>
       <td>{{ op.status }}</td>
+      {% if DEV_MODE %}
       <td>
         <a href="{{ url_for('operadores.editar', op_id=op.id) }}">Editar</a>
         <form action="{{ url_for('operadores.eliminar', op_id=op.id) }}" method="post" style="display:inline">
@@ -22,9 +30,10 @@
           <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
         </form>
       </td>
+      {% endif %}
     </tr>
   {% else %}
-    <tr><td colspan="5">No hay operadores registrados.</td></tr>
+    <tr><td colspan="{{ 5 if DEV_MODE else 4 }}">No hay operadores registrados.</td></tr>
   {% endfor %}
   </tbody>
 </table>

--- a/app/templates/partes/detalle.html
+++ b/app/templates/partes/detalle.html
@@ -13,7 +13,13 @@
 <p>Operador: {{ p.operador.nombre if p.operador else '-' }}</p>
 <p>Observaciones: {{ p.observaciones or '-' }}</p>
 <p>
-  <a class="btn" href="{{ url_for('partes.editar', parte_id=p.id) }}">Editar</a>
+  {% if DEV_MODE %}
+    <a class="btn" href="{{ url_for('partes.editar', parte_id=p.id) }}">Editar</a>
+    <form method="post" action="{{ url_for('partes.eliminar', parte_id=p.id) }}" style="display:inline" onsubmit="return confirm('¿Eliminar parte?');">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit">Eliminar</button>
+    </form>
+  {% endif %}
   <button onclick="window.print()">Imprimir</button>
   <a class="btn" href="{{ url_for('partes.index') }}">Volver al listado</a>
 </p>

--- a/app/templates/partes/index.html
+++ b/app/templates/partes/index.html
@@ -6,7 +6,9 @@
   <label>al <input type="date" name="d2" value="{{ d2 or '' }}"></label>
   <input name="q" value="{{ q }}" placeholder="Buscar por código o tipo de equipo...">
   <button type="submit">Filtrar</button>
+  {% if DEV_MODE %}
   <a class="btn" href="{{ url_for('partes.nuevo') }}">Nuevo</a>
+  {% endif %}
   <a class="btn" href="{{ url_for('partes.export_csv', d1=d1, d2=d2, q=q) }}">Exportar CSV</a>
 </form>
 <p>
@@ -22,7 +24,7 @@
       <th>Turno</th>
       <th>Horas</th>
       <th>Comb (L)</th>
-      <th></th>
+      <th>Acciones</th>
     </tr>
   </thead>
   <tbody>
@@ -36,6 +38,13 @@
       <td>{{ '%.2f'|format(r.combustible_l) if r.combustible_l is not none else '-' }}</td>
       <td>
         <a href="{{ url_for('partes.detalle', parte_id=r.id) }}">Ver</a>
+        {% if DEV_MODE %}
+          <a href="{{ url_for('partes.editar', parte_id=r.id) }}">Editar</a>
+          <form action="{{ url_for('partes.eliminar', parte_id=r.id) }}" method="post" style="display:inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" onclick="return confirm('¿Eliminar parte?')">Eliminar</button>
+          </form>
+        {% endif %}
       </td>
     </tr>
   {% else %}

--- a/app/utils/rbac.py
+++ b/app/utils/rbac.py
@@ -26,6 +26,10 @@ def require_roles(*roles: str):
     def deco(fn):
         @wraps(fn)
         def wrap(*a, **k):
+            if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
+                "LOGIN_DISABLED"
+            ):
+                return fn(*a, **k)
             if current_app.config.get("AUTH_SIMPLE", False):
                 role = _resolve_session_role()
                 if role is None:
@@ -53,6 +57,10 @@ def require_approved(fn):
 
     @wraps(fn)
     def wrap(*a, **k):
+        if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
+            "LOGIN_DISABLED"
+        ):
+            return fn(*a, **k)
         if current_app.config.get("AUTH_SIMPLE", False):
             if not session.get("user"):
                 abort(401)


### PR DESCRIPTION
## Summary
- short-circuit login and role guards when DISABLE_SECURITY is enabled
- add a jwt_required shim and relax CSRF/JWT/CORS settings for dev
- expose CRUD controls in key templates whenever DEV_MODE is active

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9c39293c88326b5737c560adfadfd