### PR TITLE
Improve dev CRUD flows with pagination and CSRF helper

### DIFF
--- a/app/blueprints/equipos/routes.py
+++ b/app/blueprints/equipos/routes.py
@@ -5,6 +5,7 @@ from flask_login import login_required
 
 from app.db import db
 from app.models import Equipo
+from app.utils.pagination import paginate
 
 from . import bp
 
@@ -23,8 +24,16 @@ def index():
                 Equipo.marca.ilike(like),
             )
         )
-    equipos = query.order_by(Equipo.codigo.asc()).all()
-    return render_template("equipos/index.html", equipos=equipos, q=q)
+    query = query.order_by(Equipo.codigo.asc())
+    page = request.args.get("page", type=int) or 1
+    per_page = min(max(request.args.get("per_page", type=int) or 20, 1), 100)
+    equipos, pagination = paginate(query, page=page, per_page=per_page)
+    return render_template(
+        "equipos/index.html",
+        equipos=equipos,
+        q=q,
+        pagination=pagination,
+    )
 
 
 @bp.get("/nuevo")

--- a/app/blueprints/operadores/routes.py
+++ b/app/blueprints/operadores/routes.py
@@ -5,6 +5,7 @@ from flask_login import login_required
 
 from app.db import db
 from app.models import Operador
+from app.utils.pagination import paginate
 
 from . import bp
 
@@ -23,8 +24,16 @@ def index():
                 Operador.puesto.ilike(like),
             )
         )
-    operadores = query.order_by(Operador.nombre.asc()).all()
-    return render_template("operadores/index.html", operadores=operadores, q=q)
+    query = query.order_by(Operador.nombre.asc())
+    page = request.args.get("page", type=int) or 1
+    per_page = min(max(request.args.get("per_page", type=int) or 20, 1), 100)
+    operadores, pagination = paginate(query, page=page, per_page=per_page)
+    return render_template(
+        "operadores/index.html",
+        operadores=operadores,
+        q=q,
+        pagination=pagination,
+    )
 
 
 @bp.get("/nuevo")

--- a/app/blueprints/partes/routes.py
+++ b/app/blueprints/partes/routes.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import joinedload
 
 from app.db import db
 from app.models import ActividadDiaria, Equipo, ParteDiaria
+from app.utils.pagination import paginate
 
 try:
     from app.models import Operador
@@ -66,11 +67,10 @@ def index():
             or_(Equipo.codigo.ilike(like), Equipo.tipo.ilike(like))
         )
 
-    rows = (
-        query.order_by(ParteDiaria.fecha.desc(), ParteDiaria.id.desc())
-        .limit(300)
-        .all()
-    )
+    query = query.order_by(ParteDiaria.fecha.desc(), ParteDiaria.id.desc())
+    page = request.args.get("page", type=int) or 1
+    per_page = min(max(request.args.get("per_page", type=int) or 20, 1), 100)
+    rows, pagination = paginate(query, page=page, per_page=per_page)
 
     total_horas = sum((r.horas_trabajadas or 0.0) for r in rows)
     total_comb = sum((r.combustible_l or 0.0) for r in rows)
@@ -83,6 +83,7 @@ def index():
         d2=d2_raw,
         total_horas=total_horas,
         total_comb=total_comb,
+        pagination=pagination,
     )
 
 

--- a/app/templates/_forms.html
+++ b/app/templates/_forms.html
@@ -1,0 +1,8 @@
+{% macro csrf_field() -%}
+  {% if csrf_token is defined %}
+    {% set token = csrf_token() %}
+    {% if token %}
+      <input type="hidden" name="csrf_token" value="{{ token }}">
+    {% endif %}
+  {% endif %}
+{%- endmacro %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="es">
 {% import "_icons.html" as i %}
+{% import "_forms.html" as forms %}
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -39,12 +40,14 @@
         <a href="{{ url_for('checklists.index') }}">Checklists</a>
         <a href="{{ url_for('operadores.index') }}">Operadores</a>
         <form method="post" action="{{ url_for('auth.logout') }}" class="inline">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {{ forms.csrf_field() }}
           <button class="btn" type="submit">Logout</button>
         </form>
       {% else %}
         <a href="{{ url_for('public.home') }}">Inicio</a>
+        {% if not DEV_MODE %}
         <a href="{{ url_for('auth.login') }}" class="btn">Login</a>
+        {% endif %}
       {% endif %}
     </nav>
   </header>

--- a/app/templates/checklists/detalle.html
+++ b/app/templates/checklists/detalle.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>{{ cl.template.name }} — {{ cl.date }} — <strong>{{ cl.overall_status }}</strong></h1>
 <p>
@@ -8,7 +9,7 @@
   {% else %}
     {% if DEV_MODE %}
     <form method="post" action="{{ url_for('checklists.generar_parte', cl_id=cl.id) }}" style="display:inline">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      {{ forms.csrf_field() }}
       <button type="submit">Generar Parte Diario</button>
     </form>
     {% endif %}

--- a/app/templates/checklists/editar.html
+++ b/app/templates/checklists/editar.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Checklist — {{ cl.template.name }} / {{ cl.overall_status }}</h1>
 <form method="post" action="{{ url_for('checklists.guardar', cl_id=cl.id) }}" enctype="multipart/form-data">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   {% for section, items in items_by_section.items() %}
     <h2>{{ "Pre-operativo" if section == "PRE" else ("Operación" if section == "OP" else "Post-operativo") }}</h2>
     <table>

--- a/app/templates/checklists/index.html
+++ b/app/templates/checklists/index.html
@@ -37,4 +37,15 @@
   {% endfor %}
   </tbody>
 </table>
+{% if pagination.pages > 1 %}
+<nav class="pagination">
+  {% if pagination.has_prev %}
+  <a href="{{ url_for('checklists.index', page=pagination.prev_num, q=q, per_page=pagination.per_page) }}">« Anterior</a>
+  {% endif %}
+  <span>Página {{ pagination.page }} de {{ pagination.pages }}</span>
+  {% if pagination.has_next %}
+  <a href="{{ url_for('checklists.index', page=pagination.next_num, q=q, per_page=pagination.per_page) }}">Siguiente »</a>
+  {% endif %}
+</nav>
+{% endif %}
 {% endblock %}

--- a/app/templates/checklists/nuevo.html
+++ b/app/templates/checklists/nuevo.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Nuevo checklist</h1>
 <form method="post" action="{{ url_for('checklists.crear') }}">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   <label>Equipo:
     <select name="equipment_id" required>
       {% for e in equipos %}

--- a/app/templates/equipos/form.html
+++ b/app/templates/equipos/form.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>{{ 'Editar' if equipo else 'Nuevo' }} equipo</h1>
 <form method="post" action="{{ url_for('equipos.actualizar', equipo_id=equipo.id) if equipo else url_for('equipos.crear') }}">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   {% for name,label in [('codigo','Código'),('tipo','Tipo'),('marca','Marca'),('modelo','Modelo'),('serie','Serie'),('placas','Placas'),('status','Status'),('ubicacion','Ubicación'),('horas_uso','Horas de uso')] %}
     <label>{{ label }} <input name="{{ name }}" value="{{ getattr(equipo, name, '') if equipo else '' }}"></label><br>
   {% endfor %}

--- a/app/templates/equipos/index.html
+++ b/app/templates/equipos/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Equipos</h1>
 <form method="get" class="mb-3">
@@ -24,7 +25,7 @@
       <td>
         <a href="{{ url_for('equipos.editar', equipo_id=equipo.id) }}">Editar</a>
         <form action="{{ url_for('equipos.eliminar', equipo_id=equipo.id) }}" method="post" style="display:inline">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {{ forms.csrf_field() }}
           <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
         </form>
       </td>
@@ -35,4 +36,15 @@
   {% endfor %}
   </tbody>
 </table>
+{% if pagination.pages > 1 %}
+<nav class="pagination">
+  {% if pagination.has_prev %}
+  <a href="{{ url_for('equipos.index', page=pagination.prev_num, q=q, per_page=pagination.per_page) }}">« Anterior</a>
+  {% endif %}
+  <span>Página {{ pagination.page }} de {{ pagination.pages }}</span>
+  {% if pagination.has_next %}
+  <a href="{{ url_for('equipos.index', page=pagination.next_num, q=q, per_page=pagination.per_page) }}">Siguiente »</a>
+  {% endif %}
+</nav>
+{% endif %}
 {% endblock %}

--- a/app/templates/operadores/form.html
+++ b/app/templates/operadores/form.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>{{ 'Editar' if op else 'Nuevo' }} operador</h1>
 <form method="post" action="{{ url_for('operadores.actualizar', op_id=op.id) if op else url_for('operadores.crear') }}">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   {% for name,label in [('nombre','Nombre'),('identificacion','Identificación'),('licencia','Licencia'),('puesto','Puesto'),('telefono','Teléfono'),('status','Status')] %}
     <label>{{ label }} <input name="{{ name }}" value="{{ getattr(op, name, '') if op else '' }}"></label><br>
   {% endfor %}

--- a/app/templates/operadores/index.html
+++ b/app/templates/operadores/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Operadores</h1>
 <form method="get" class="mb-3">
@@ -26,7 +27,7 @@
       <td>
         <a href="{{ url_for('operadores.editar', op_id=op.id) }}">Editar</a>
         <form action="{{ url_for('operadores.eliminar', op_id=op.id) }}" method="post" style="display:inline">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {{ forms.csrf_field() }}
           <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
         </form>
       </td>
@@ -37,4 +38,15 @@
   {% endfor %}
   </tbody>
 </table>
+{% if pagination.pages > 1 %}
+<nav class="pagination">
+  {% if pagination.has_prev %}
+  <a href="{{ url_for('operadores.index', page=pagination.prev_num, q=q, per_page=pagination.per_page) }}">« Anterior</a>
+  {% endif %}
+  <span>Página {{ pagination.page }} de {{ pagination.pages }}</span>
+  {% if pagination.has_next %}
+  <a href="{{ url_for('operadores.index', page=pagination.next_num, q=q, per_page=pagination.per_page) }}">Siguiente »</a>
+  {% endif %}
+</nav>
+{% endif %}
 {% endblock %}

--- a/app/templates/partes/detalle.html
+++ b/app/templates/partes/detalle.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Parte — {{ p.fecha }} — Equipo {{ p.equipo.codigo if p.equipo else p.equipo_id }}</h1>
 {% if p.checklist_id %}
@@ -16,7 +17,7 @@
   {% if DEV_MODE %}
     <a class="btn" href="{{ url_for('partes.editar', parte_id=p.id) }}">Editar</a>
     <form method="post" action="{{ url_for('partes.eliminar', parte_id=p.id) }}" style="display:inline" onsubmit="return confirm('¿Eliminar parte?');">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      {{ forms.csrf_field() }}
       <button type="submit">Eliminar</button>
     </form>
   {% endif %}

--- a/app/templates/partes/editar.html
+++ b/app/templates/partes/editar.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Parte — {{ p.fecha }} — Equipo {{ p.equipo.codigo if p.equipo else p.equipo_id }}</h1>
 <form method="post" action="{{ url_for('partes.actualizar', parte_id=p.id) }}" class="form-grid">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   <label>Fecha: <input type="date" name="fecha" value="{{ p.fecha }}"></label>
   <label>Equipo:
     <select name="equipo_id">
@@ -35,7 +36,7 @@
   </div>
 </form>
 <form method="post" action="{{ url_for('partes.eliminar', parte_id=p.id) }}" onsubmit="return confirm('¿Eliminar parte?');">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   <button type="submit" class="btn btn-danger">Eliminar parte</button>
 </form>
 
@@ -54,7 +55,7 @@
       <td>{{ a.notas or '' }}</td>
       <td>
         <form method="post" action="{{ url_for('partes.eliminar_actividad', parte_id=p.id, act_id=a.id) }}" onsubmit="return confirm('¿Eliminar actividad?');">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          {{ forms.csrf_field() }}
           <button type="submit">Eliminar</button>
         </form>
       </td>
@@ -67,7 +68,7 @@
 
 <h3>Agregar actividad</h3>
 <form method="post" action="{{ url_for('partes.agregar_actividad', parte_id=p.id) }}" class="form-grid">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   <input name="descripcion" placeholder="Descripción" required>
   <input name="cantidad" type="number" step="0.01" placeholder="Cantidad">
   <input name="unidad" placeholder="Unidad (m3, viajes, etc.)">

--- a/app/templates/partes/index.html
+++ b/app/templates/partes/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Partes diarios</h1>
 <form method="get" class="mb-3 filters">
@@ -41,7 +42,7 @@
         {% if DEV_MODE %}
           <a href="{{ url_for('partes.editar', parte_id=r.id) }}">Editar</a>
           <form action="{{ url_for('partes.eliminar', parte_id=r.id) }}" method="post" style="display:inline">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {{ forms.csrf_field() }}
             <button type="submit" onclick="return confirm('¿Eliminar parte?')">Eliminar</button>
           </form>
         {% endif %}
@@ -52,4 +53,15 @@
   {% endfor %}
   </tbody>
 </table>
+{% if pagination.pages > 1 %}
+<nav class="pagination">
+  {% if pagination.has_prev %}
+  <a href="{{ url_for('partes.index', page=pagination.prev_num, q=q, d1=d1, d2=d2, per_page=pagination.per_page) }}">« Anterior</a>
+  {% endif %}
+  <span>Página {{ pagination.page }} de {{ pagination.pages }}</span>
+  {% if pagination.has_next %}
+  <a href="{{ url_for('partes.index', page=pagination.next_num, q=q, d1=d1, d2=d2, per_page=pagination.per_page) }}">Siguiente »</a>
+  {% endif %}
+</nav>
+{% endif %}
 {% endblock %}

--- a/app/templates/partes/nuevo.html
+++ b/app/templates/partes/nuevo.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
+{% import "_forms.html" as forms %}
 {% block content %}
 <h1>Nuevo parte diario</h1>
 <form method="post" action="{{ url_for('partes.crear') }}" class="form-grid">
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  {{ forms.csrf_field() }}
   <label>Fecha: <input type="date" name="fecha" value="{{ pre.fecha if pre else hoy }}"></label>
   <label>Equipo:
     <select name="equipo_id" required>

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -1,0 +1,68 @@
+"""Utility helpers for paginating SQLAlchemy queries in Flask views."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.extensions import db
+
+
+@dataclass
+class SimplePagination:
+    """Lightweight pagination object mimicking Flask-SQLAlchemy's API."""
+
+    page: int
+    per_page: int
+    total: int
+    pages: int
+
+    @property
+    def has_prev(self) -> bool:
+        return self.page > 1
+
+    @property
+    def has_next(self) -> bool:
+        return self.page < self.pages
+
+    @property
+    def prev_num(self) -> int | None:
+        return self.page - 1 if self.has_prev else None
+
+    @property
+    def next_num(self) -> int | None:
+        return self.page + 1 if self.has_next else None
+
+
+def paginate(query, page: int, per_page: int):
+    """Return items and a pagination object for the given query.
+
+    Falls back to manual pagination when Flask-SQLAlchemy's helper is not
+    available (e.g., during unit tests or when using a plain SQLAlchemy query).
+    """
+
+    page = max(int(page or 1), 1)
+    per_page = max(int(per_page or 1), 1)
+
+    try:
+        pagination = db.paginate(
+            query,
+            page=page,
+            per_page=per_page,
+            error_out=False,
+        )
+        items = list(pagination.items)
+        return items, pagination
+    except Exception:
+        total = query.count()
+        pages = max((total + per_page - 1) // per_page, 1)
+        if page > pages:
+            page = pages
+        offset = max((page - 1) * per_page, 0)
+        items = list(query.offset(offset).limit(per_page).all())
+        pagination = SimplePagination(
+            page=page,
+            per_page=per_page,
+            total=total,
+            pages=pages,
+        )
+        return items, pagination

--- a/render.yaml
+++ b/render.yaml
@@ -16,10 +16,9 @@ services:
                   "ALTER COLUMN version_num TYPE VARCHAR(128)"
               )
           )
-          print("OK: alembic_version.version_num = VARCHAR(128)")
+      print("OK: alembic_version.version_num ensure 128")
       PY
       && alembic -c migrations/alembic.ini upgrade head
-      && FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password admin123
     startCommand: gunicorn -w 2 -k gthread -t 120 -b 0.0.0.0:$PORT 'app:create_app()'
     healthCheckPath: /healthz
     envVars:


### PR DESCRIPTION
## Summary
- add a reusable pagination helper and apply it to equipos, operadores, checklists, and partes listings with UI controls
- centralize CSRF field rendering for dev mode templates and hide the login button when security is disabled
- simplify the Render pre-deploy command to only adjust the alembic version column and run migrations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d2be76e48326a667ba66db6ba785