### PR TITLE
Rename equipos blueprint to avoid name clash

### DIFF
--- a/app/blueprints/equipos/__init__.py
+++ b/app/blueprints/equipos/__init__.py
@@ -4,7 +4,7 @@ from flask import Blueprint
 
 from app.security import require_login
 
-bp = Blueprint("equipos", __name__, url_prefix="/equipos")
+bp = Blueprint("equipos_bp", __name__, url_prefix="/equipos")
 
 require_login(bp, exclude=("index",))
 

--- a/app/blueprints/equipos/routes.py
+++ b/app/blueprints/equipos/routes.py
@@ -63,15 +63,15 @@ def crear():
             data["horas_uso"] = float(horas_uso_raw)
         except (TypeError, ValueError):
             flash("Horas de uso inválidas", "error")
-            return redirect(url_for("equipos.nuevo"))
+            return redirect(url_for("equipos_bp.nuevo"))
     if not data.get("codigo") or not data.get("tipo"):
         flash("Código y tipo son obligatorios", "error")
-        return redirect(url_for("equipos.nuevo"))
+        return redirect(url_for("equipos_bp.nuevo"))
     equipo = Equipo(**data)
     db.session.add(equipo)
     db.session.commit()
     flash("Equipo creado", "success")
-    return redirect(url_for("equipos.index"))
+    return redirect(url_for("equipos_bp.index"))
 
 
 @bp.get("/<int:equipo_id>/editar")
@@ -104,11 +104,11 @@ def actualizar(equipo_id: int):
                 value = float(value)
             except (TypeError, ValueError):
                 flash("Horas de uso inválidas", "error")
-                return redirect(url_for("equipos.editar", equipo_id=equipo.id))
+                return redirect(url_for("equipos_bp.editar", equipo_id=equipo.id))
         setattr(equipo, key, value)
     db.session.commit()
     flash("Equipo actualizado", "success")
-    return redirect(url_for("equipos.index"))
+    return redirect(url_for("equipos_bp.index"))
 
 
 @bp.post("/<int:equipo_id>/eliminar")
@@ -118,7 +118,7 @@ def eliminar(equipo_id: int):
     db.session.delete(equipo)
     db.session.commit()
     flash("Equipo eliminado", "success")
-    return redirect(url_for("equipos.index"))
+    return redirect(url_for("equipos_bp.index"))
 
 
 @bp.get("/<int:equipo_id>")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,7 @@
     </div>
     <nav class="nav-right">
       {% if current_user.is_authenticated %}
-        <a href="{{ url_for('equipos.index') }}">Equipos</a>
+        <a href="{{ url_for('equipos_bp.index') }}">Equipos</a>
         <a href="{{ url_for('partes.index') }}">Partes</a>
         <a href="{{ url_for('checklists.index') }}">Checklists</a>
         <a href="{{ url_for('operadores.index') }}">Operadores</a>
@@ -56,7 +56,7 @@
     {% if current_user.is_authenticated %}
       <nav>
         <a href="{{ url_for('dashboard.home') }}">Inicio</a> |
-        <a href="{{ url_for('equipos.index') }}">Equipos</a> |
+        <a href="{{ url_for('equipos_bp.index') }}">Equipos</a> |
         <a href="{{ url_for('operadores.index') }}">Operadores</a> |
         <a href="{{ url_for('checklists.index') }}">Checklists</a> |
         <a href="{{ url_for('partes.index') }}">Partes</a>

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -7,7 +7,7 @@
 <p>
   <a href="{{ url_for('checklists.nuevo') }}">➕ Nuevo Checklist</a> |
   <a href="{{ url_for('partes.nuevo') }}">➕ Nuevo Parte</a> |
-  <a href="{{ url_for('equipos.nuevo') }}">➕ Nuevo Equipo</a>
+  <a href="{{ url_for('equipos_bp.nuevo') }}">➕ Nuevo Equipo</a>
   {% if total_operadores is not none %}| <a href="{{ url_for('operadores.nuevo') }}">➕ Nuevo Operador</a>{% endif %}
 </p>
 {% endif %}

--- a/app/templates/equipos/detalle.html
+++ b/app/templates/equipos/detalle.html
@@ -11,6 +11,6 @@
   <li>Horas de uso: {{ equipo.horas_uso }}</li>
 </ul>
 {% if DEV_MODE %}
-<a href="{{ url_for('equipos.editar', equipo_id=equipo.id) }}">Editar</a>
+<a href="{{ url_for('equipos_bp.editar', equipo_id=equipo.id) }}">Editar</a>
 {% endif %}
 {% endblock %}

--- a/app/templates/equipos/form.html
+++ b/app/templates/equipos/form.html
@@ -2,7 +2,10 @@
 {% import "_forms.html" as forms %}
 {% block content %}
 <h1>{{ 'Editar' if equipo else 'Nuevo' }} equipo</h1>
-<form method="post" action="{{ url_for('equipos.actualizar', equipo_id=equipo.id) if equipo else url_for('equipos.crear') }}">
+<form method="post" action="{{
+  url_for('equipos_bp.actualizar', equipo_id=equipo.id)
+  if equipo else url_for('equipos_bp.crear')
+}}">
   {{ forms.csrf_field() }}
   {% for name,label in [('codigo','Código'),('tipo','Tipo'),('marca','Marca'),('modelo','Modelo'),('serie','Serie'),('placas','Placas'),('status','Status'),('ubicacion','Ubicación'),('horas_uso','Horas de uso')] %}
     <label>{{ label }} <input name="{{ name }}" value="{{ getattr(equipo, name, '') if equipo else '' }}"></label><br>

--- a/app/templates/equipos/index.html
+++ b/app/templates/equipos/index.html
@@ -6,7 +6,7 @@
   <input name="q" value="{{ q }}" placeholder="Buscar por código / tipo / marca">
   <button type="submit">Buscar</button>
   {% if DEV_MODE %}
-  <a href="{{ url_for('equipos.nuevo') }}">Nuevo</a>
+  <a href="{{ url_for('equipos_bp.nuevo') }}">Nuevo</a>
   {% endif %}
 </form>
 <table>
@@ -19,12 +19,12 @@
   <tbody>
   {% for equipo in equipos %}
     <tr>
-      <td><a href="{{ url_for('equipos.detalle', equipo_id=equipo.id) }}">{{ equipo.codigo }}</a></td>
+      <td><a href="{{ url_for('equipos_bp.detalle', equipo_id=equipo.id) }}">{{ equipo.codigo }}</a></td>
       <td>{{ equipo.tipo }}</td><td>{{ equipo.marca or '-' }}</td><td>{{ equipo.status }}</td>
       {% if DEV_MODE %}
       <td>
-        <a href="{{ url_for('equipos.editar', equipo_id=equipo.id) }}">Editar</a>
-        <form action="{{ url_for('equipos.eliminar', equipo_id=equipo.id) }}" method="post" style="display:inline">
+        <a href="{{ url_for('equipos_bp.editar', equipo_id=equipo.id) }}">Editar</a>
+        <form action="{{ url_for('equipos_bp.eliminar', equipo_id=equipo.id) }}" method="post" style="display:inline">
           {{ forms.csrf_field() }}
           <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
         </form>
@@ -39,11 +39,11 @@
 {% if pagination.pages > 1 %}
 <nav class="pagination">
   {% if pagination.has_prev %}
-  <a href="{{ url_for('equipos.index', page=pagination.prev_num, q=q, per_page=pagination.per_page) }}">« Anterior</a>
+  <a href="{{ url_for('equipos_bp.index', page=pagination.prev_num, q=q, per_page=pagination.per_page) }}">« Anterior</a>
   {% endif %}
   <span>Página {{ pagination.page }} de {{ pagination.pages }}</span>
   {% if pagination.has_next %}
-  <a href="{{ url_for('equipos.index', page=pagination.next_num, q=q, per_page=pagination.per_page) }}">Siguiente »</a>
+  <a href="{{ url_for('equipos_bp.index', page=pagination.next_num, q=q, per_page=pagination.per_page) }}">Siguiente »</a>
   {% endif %}
 </nav>
 {% endif %}


### PR DESCRIPTION
## Summary
- rename the equipos blueprint to `equipos_bp` to prevent name collisions during app startup
- update all `url_for` usages in equipos templates and views to reference the renamed blueprint

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68d9eb1d54308326be51a9461c47ae26