### PR TITLE
Add PDF exports and summary for partes diarias

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,6 +37,9 @@
       {% if current_user.is_authenticated %}
         <a href="{{ url_for('equipos_bp.index') }}">Equipos</a>
         <a href="{{ url_for('partes.index') }}">Partes</a>
+        {% if DEV_MODE %}
+        <a href="{{ url_for('partes.resumen') }}">Resumen Partes</a>
+        {% endif %}
         <a href="{{ url_for('checklists.index') }}">Checklists</a>
         <a href="{{ url_for('operadores.index') }}">Operadores</a>
         <form method="post" action="{{ url_for('auth.logout') }}" class="inline">
@@ -60,6 +63,9 @@
         <a href="{{ url_for('operadores.index') }}">Operadores</a> |
         <a href="{{ url_for('checklists.index') }}">Checklists</a> |
         <a href="{{ url_for('partes.index') }}">Partes</a>
+        {% if DEV_MODE %}|
+        <a href="{{ url_for('partes.resumen') }}">Resumen Partes</a>
+        {% endif %}
       </nav>
       <hr>
     {% endif %}

--- a/app/templates/partes/index.html
+++ b/app/templates/partes/index.html
@@ -18,6 +18,7 @@
   </select>
   <button type="submit">Filtrar</button>
   <a href="{{ url_for('partes.export_csv', desde=desde.isoformat() if desde else None, hasta=hasta.isoformat() if hasta else None, equipo_id=equipo_id) }}">Exportar CSV</a>
+  <a href="{{ url_for('partes.resumen', desde=desde.isoformat() if desde else None, hasta=hasta.isoformat() if hasta else None, equipo_id=equipo_id) }}">Resumen</a>
   {% if DEV_MODE %}
     <a href="{{ url_for('partes.create') }}">+ Nuevo</a>
   {% endif %}
@@ -46,6 +47,7 @@
       <td>{{ r.incidencias }}</td>
       {% if DEV_MODE %}
       <td>
+        <a href="{{ url_for('partes.pdf_parte', id=r.id) }}" target="_blank">PDF</a>
         <a href="{{ url_for('partes.edit', id=r.id) }}">Editar</a>
         <form method="post" action="{{ url_for('partes.delete', id=r.id) }}" style="display:inline" onsubmit="return confirm('¿Eliminar parte?');">
           <button type="submit">Eliminar</button>

--- a/app/templates/partes/resumen.html
+++ b/app/templates/partes/resumen.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="mb-3">Resumen de partes diarias</h1>
+
+<form method="get" class="mb-3" action="{{ url_for('partes.resumen') }}">
+  <label>Desde</label>
+  <input type="date" name="desde" value="{{ (desde or '') }}">
+  <label>Hasta</label>
+  <input type="date" name="hasta" value="{{ (hasta or '') }}">
+  <label>Equipo</label>
+  <select name="equipo_id">
+    <option value="">-- todos --</option>
+    {% for e in equipos %}
+      <option value="{{ e.id }}" {% if equipo_id and equipo_id==e.id %}selected{% endif %}>
+        {{ getattr(e,'nombre','Equipo') }} #{{ e.id }}
+      </option>
+    {% endfor %}
+  </select>
+  <button type="submit">Filtrar</button>
+  <a href="{{ url_for('partes.resumen_pdf', desde=desde, hasta=hasta, equipo_id=equipo_id) }}">Descargar PDF</a>
+</form>
+
+<div class="cards">
+  <div class="card">Partes: <strong>{{ partes_count }}</strong></div>
+  <div class="card">Total horas: <strong>{{ '%.2f'|format(total_horas) }}</strong></div>
+  <div class="card">Con incidencias: <strong>{{ incidencias_count }}</strong></div>
+</div>
+
+<h3 class="mt-3">Últimos registros</h3>
+<table class="table">
+  <thead><tr><th>Fecha</th><th>Equipo</th><th>Operador</th><th>Horas</th><th>Actividad</th><th>Incidencias</th></tr></thead>
+  <tbody>
+    {% for r in ultimos %}
+      <tr>
+        <td>{{ r.fecha }}</td>
+        <td>{{ r.equipo_id }}</td>
+        <td>{{ r.operador_id }}</td>
+        <td>{{ r.horas_trabajo }}</td>
+        <td>{{ r.actividad }}</td>
+        <td>{{ r.incidencias }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<style>
+.cards{display:flex;gap:12px;flex-wrap:wrap}
+.card{padding:10px 14px;border:1px solid #333;border-radius:8px}
+</style>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ pytz>=2024.1
 
 # Metrics
 prometheus-client>=0.20.0
+
+# PDF generation
+reportlab>=4.0.0

--- a/tests/partes/test_partes_pdf_resumen.py
+++ b/tests/partes/test_partes_pdf_resumen.py
@@ -1,0 +1,21 @@
+from datetime import date
+
+def test_pdf_parte_smoke(client, monkeypatch):
+    from app.extensions import db
+    from app.models.parte_diaria import ParteDiaria
+
+    monkeypatch.setenv("DISABLE_SECURITY", "1")
+    p = ParteDiaria(fecha=date.today(), horas_trabajo=1.0)
+    db.session.add(p)
+    db.session.commit()
+
+    r = client.get(f"/partes/{p.id}/pdf")
+    assert r.status_code == 200
+    assert r.headers.get("Content-Type", "").startswith("application/pdf")
+
+
+def test_resumen_pdf_smoke(client, monkeypatch):
+    monkeypatch.setenv("DISABLE_SECURITY", "1")
+    r = client.get("/partes/resumen.pdf")
+    assert r.status_code == 200
+    assert r.headers.get("Content-Type", "").startswith("application/pdf")


### PR DESCRIPTION
## Summary
- add ReportLab dependency and shared PDF header/footer helper for partes diarias exports
- expose individual parte PDF download plus HTML/PDF summary views with navigation links
- cover the new endpoints with smoke tests

## Testing
- pytest tests/partes/test_partes_pdf_resumen.py

------
https://chatgpt.com/codex/tasks/task_e_68da28da9a00832687f9d532d9d88cb0