### PR TITLE
Implement operadores MVP and exports

### DIFF
--- a/app/blueprints/operadores/__init__.py
+++ b/app/blueprints/operadores/__init__.py
@@ -4,7 +4,12 @@ from flask import Blueprint
 
 from app.security import require_login
 
-bp = Blueprint("operadores", __name__, url_prefix="/operadores")
+bp = Blueprint(
+    "operadores_bp",
+    __name__,
+    url_prefix="/operadores",
+    template_folder="../../templates/operadores",
+)
 
 require_login(bp, exclude=("index",))
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -167,19 +167,21 @@ def register_cli(app):
         data = [
             {
                 "nombre": "Juan Pérez",
-                "identificacion": "OP-001",
-                "puesto": "operador",
-                "licencia": "A",
+                "doc_id": "LIC-001",
+                "licencia_vence": date.today(),
+                "notas": "Operador principal de excavadora.",
+                "estatus": "activo",
             },
             {
                 "nombre": "María López",
-                "identificacion": "OP-002",
-                "puesto": "ayudante",
-                "licencia": "-",
+                "doc_id": "LIC-002",
+                "licencia_vence": date.today(),
+                "notas": "Respaldo turno nocturno.",
+                "estatus": "activo",
             },
         ]
         for payload in data:
-            if not Operador.query.filter_by(identificacion=payload.get("identificacion")).first():
+            if not Operador.query.filter_by(doc_id=payload.get("doc_id")).first():
                 db.session.add(Operador(**payload))
         db.session.commit()
         click.echo("Operadores seed: OK")

--- a/app/models/operador.py
+++ b/app/models/operador.py
@@ -1,26 +1,27 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date
 
-from app.db import db
+from app.extensions import db
 
 
 class Operador(db.Model):
     __tablename__ = "operadores"
 
     id = db.Column(db.Integer, primary_key=True)
-    nombre = db.Column(db.String(120), nullable=False, index=True)
-    identificacion = db.Column(db.String(64), unique=True)
-    licencia = db.Column(db.String(64))
-    puesto = db.Column(db.String(64))
-    telefono = db.Column(db.String(32))
-    status = db.Column(db.String(32), default="activo")
-    fecha_alta = db.Column(db.Date, default=datetime.utcnow)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    nombre = db.Column(db.String(160), nullable=False)
+    doc_id = db.Column(db.String(80))
+    licencia_vence = db.Column(db.Date)
+    notas = db.Column(db.Text)
+    estatus = db.Column(db.String(32), default="activo")
 
     partes = db.relationship(
         "ParteDiaria",
         back_populates="operador",
         lazy="dynamic",
     )
+
+    def dias_para_vencer(self) -> int | None:
+        if not self.licencia_vence:
+            return None
+        return (self.licencia_vence - date.today()).days

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -43,7 +43,7 @@
         <a href="{{ url_for('checklists_bp.runs_index') }}">Ejecuciones</a>
         <a href="{{ url_for('partes.resumen') }}">Resumen Partes</a>
         {% endif %}
-        <a href="{{ url_for('operadores.index') }}">Operadores</a>
+        <a href="{{ url_for('operadores_bp.index') }}">Operadores</a>
         <form method="post" action="{{ url_for('auth.logout') }}" class="inline">
           {{ forms.csrf_field() }}
           <button class="btn" type="submit">Logout</button>
@@ -62,7 +62,7 @@
       <nav>
         <a href="{{ url_for('dashboard.home') }}">Inicio</a> |
         <a href="{{ url_for('equipos_bp.index') }}">Equipos</a> |
-        <a href="{{ url_for('operadores.index') }}">Operadores</a> |
+        <a href="{{ url_for('operadores_bp.index') }}">Operadores</a> |
         <a href="{{ url_for('checklists_bp.templates_index') }}">Checklists</a>
         {% if DEV_MODE %}|
         <a href="{{ url_for('checklists_bp.ejecutar') }}">Ejecutar</a> |

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -8,7 +8,7 @@
   <a href="{{ url_for('checklists_bp.ejecutar') }}">➕ Ejecutar Checklist</a> |
   <a href="{{ url_for('partes.create') }}">➕ Nuevo Parte</a> |
   <a href="{{ url_for('equipos_bp.nuevo') }}">➕ Nuevo Equipo</a>
-  {% if total_operadores is not none %}| <a href="{{ url_for('operadores.nuevo') }}">➕ Nuevo Operador</a>{% endif %}
+  {% if total_operadores is not none %}| <a href="{{ url_for('operadores_bp.create') }}">➕ Nuevo Operador</a>{% endif %}
 </p>
 {% endif %}
 

--- a/app/templates/equipos/index.html
+++ b/app/templates/equipos/index.html
@@ -8,6 +8,7 @@
   {% if DEV_MODE %}
   <a href="{{ url_for('equipos_bp.nuevo') }}">Nuevo</a>
   {% endif %}
+  <a href="{{ url_for('equipos_bp.export_csv') }}">Exportar CSV</a>
 </form>
 <table>
   <thead>

--- a/app/templates/operadores/detalle.html
+++ b/app/templates/operadores/detalle.html
@@ -2,13 +2,12 @@
 {% block content %}
 <h1>{{ op.nombre }}</h1>
 <ul>
-  <li>Identificación: {{ op.identificacion or '-' }}</li>
-  <li>Licencia: {{ op.licencia or '-' }}</li>
-  <li>Puesto: {{ op.puesto or '-' }}</li>
-  <li>Teléfono: {{ op.telefono or '-' }}</li>
-  <li>Status: {{ op.status }}</li>
+  <li>Documento: {{ op.doc_id or '-' }}</li>
+  <li>Licencia vence: {{ op.licencia_vence or '-' }}</li>
+  <li>Estatus: {{ op.estatus or '-' }}</li>
+  <li>Notas: {{ op.notas or '-' }}</li>
 </ul>
 {% if DEV_MODE %}
-<a href="{{ url_for('operadores.editar', op_id=op.id) }}">Editar</a>
+<a href="{{ url_for('operadores_bp.edit', operador_id=op.id) }}">Editar</a>
 {% endif %}
 {% endblock %}

--- a/app/templates/operadores/form.html
+++ b/app/templates/operadores/form.html
@@ -1,12 +1,28 @@
 {% extends "base.html" %}
 {% import "_forms.html" as forms %}
 {% block content %}
-<h1>{{ 'Editar' if op else 'Nuevo' }} operador</h1>
-<form method="post" action="{{ url_for('operadores.actualizar', op_id=op.id) if op else url_for('operadores.crear') }}">
+<h1 class="mb-3">{{ 'Editar' if item else 'Nuevo' }} operador</h1>
+
+<form method="post">
   {{ forms.csrf_field() }}
-  {% for name,label in [('nombre','Nombre'),('identificacion','Identificación'),('licencia','Licencia'),('puesto','Puesto'),('telefono','Teléfono'),('status','Status')] %}
-    <label>{{ label }} <input name="{{ name }}" value="{{ getattr(op, name, '') if op else '' }}"></label><br>
-  {% endfor %}
-  <button type="submit">Guardar</button>
+  <label>Nombre</label>
+  <input name="nombre" required value="{{ getattr(item,'nombre','') }}">
+
+  <label>Documento / Licencia</label>
+  <input name="doc_id" value="{{ getattr(item,'doc_id','') }}">
+
+  <label>Licencia vence</label>
+  <input type="date" name="licencia_vence" value="{{ (item.licencia_vence if item else none) or '' }}">
+
+  <label>Estatus</label>
+  <input name="estatus" value="{{ getattr(item,'estatus','') or 'activo' }}">
+
+  <label>Notas</label>
+  <textarea name="notas">{{ getattr(item,'notas','') }}</textarea>
+
+  <div class="mt-2">
+    <button type="submit">Guardar</button>
+    <a href="{{ url_for('operadores_bp.index') }}">Cancelar</a>
+  </div>
 </form>
 {% endblock %}

--- a/app/templates/operadores/index.html
+++ b/app/templates/operadores/index.html
@@ -1,52 +1,58 @@
 {% extends "base.html" %}
 {% import "_forms.html" as forms %}
 {% block content %}
-<h1>Operadores</h1>
-<form method="get" class="mb-3">
-  <input name="q" value="{{ q }}" placeholder="Buscar por nombre / ID / puesto">
-  <button type="submit">Buscar</button>
-  {% if DEV_MODE %}
-  <a href="{{ url_for('operadores.nuevo') }}">Nuevo</a>
-  {% endif %}
+<h1 class="mb-3">Operadores</h1>
+
+<form method="get" class="mb-3" action="{{ url_for('operadores_bp.index') }}">
+  <input type="text" name="q" value="{{ q or '' }}" placeholder="Buscar nombre, doc o notas">
+  <select name="vence_en">
+    <option value="">Vencen en...</option>
+    {% for d in [7, 15, 30, 60, 90] %}
+      <option value="{{ d }}" {% if vence_en == d %}selected{% endif %}>{{ d }} días</option>
+    {% endfor %}
+  </select>
+  <button type="submit">Filtrar</button>
+  <a href="{{ url_for('operadores_bp.export_csv', q=q, vence_en=vence_en) }}">Exportar CSV</a>
+  {% if DEV_MODE %}<a href="{{ url_for('operadores_bp.create') }}">+ Nuevo</a>{% endif %}
 </form>
-<table>
+
+<table class="table">
   <thead>
-    <tr>
-      <th>Nombre</th><th>ID</th><th>Puesto</th><th>Status</th>
-      {% if DEV_MODE %}<th></th>{% endif %}
-    </tr>
+    <tr><th>ID</th><th>Nombre</th><th>Doc</th><th>Licencia vence</th><th>Días</th><th>Estatus</th>{% if DEV_MODE %}<th>Acciones</th>{% endif %}</tr>
   </thead>
   <tbody>
-  {% for op in operadores %}
-    <tr>
-      <td><a href="{{ url_for('operadores.detalle', op_id=op.id) }}">{{ op.nombre }}</a></td>
-      <td>{{ op.identificacion or '-' }}</td>
-      <td>{{ op.puesto or '-' }}</td>
-      <td>{{ op.status }}</td>
+    {% for r in rows %}
+    {% set d = r.dias_para_vencer() %}
+    <tr {% if d is not none and d <= 15 %}style="background:#fff3cd"{% endif %}>
+      <td>{{ r.id }}</td>
+      <td>{{ r.nombre }}</td>
+      <td>{{ r.doc_id }}</td>
+      <td>{{ r.licencia_vence or '' }}</td>
+      <td>{{ d if d is not none else '' }}</td>
+      <td>{{ r.estatus }}</td>
       {% if DEV_MODE %}
       <td>
-        <a href="{{ url_for('operadores.editar', op_id=op.id) }}">Editar</a>
-        <form action="{{ url_for('operadores.eliminar', op_id=op.id) }}" method="post" style="display:inline">
+        <a href="{{ url_for('operadores_bp.edit', operador_id=r.id) }}">Editar</a>
+        <form method="post" action="{{ url_for('operadores_bp.delete', operador_id=r.id) }}" style="display:inline" onsubmit="return confirm('¿Eliminar operador?');">
           {{ forms.csrf_field() }}
-          <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+          <button type="submit">Eliminar</button>
         </form>
       </td>
       {% endif %}
     </tr>
-  {% else %}
-    <tr><td colspan="{{ 5 if DEV_MODE else 4 }}">No hay operadores registrados.</td></tr>
-  {% endfor %}
+    {% else %}
+    <tr>
+      <td colspan="{{ 7 if DEV_MODE else 6 }}">No hay operadores registrados.</td>
+    </tr>
+    {% endfor %}
   </tbody>
 </table>
+
 {% if pagination.pages > 1 %}
-<nav class="pagination">
-  {% if pagination.has_prev %}
-  <a href="{{ url_for('operadores.index', page=pagination.prev_num, q=q, per_page=pagination.per_page) }}">« Anterior</a>
-  {% endif %}
+<nav>
+  {% if pagination.has_prev %}<a href="{{ url_for('operadores_bp.index', page=pagination.prev_num, q=q, vence_en=vence_en) }}">&laquo; Anterior</a>{% endif %}
   <span>Página {{ pagination.page }} de {{ pagination.pages }}</span>
-  {% if pagination.has_next %}
-  <a href="{{ url_for('operadores.index', page=pagination.next_num, q=q, per_page=pagination.per_page) }}">Siguiente »</a>
-  {% endif %}
+  {% if pagination.has_next %}<a href="{{ url_for('operadores_bp.index', page=pagination.next_num, q=q, vence_en=vence_en) }}">Siguiente &raquo;</a>{% endif %}
 </nav>
 {% endif %}
 {% endblock %}

--- a/migrations/versions/20251011_create_operadores_table.py
+++ b/migrations/versions/20251011_create_operadores_table.py
@@ -16,36 +16,16 @@ def upgrade() -> None:
     op.create_table(
         "operadores",
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("nombre", sa.String(length=120), nullable=False),
-        sa.Column("identificacion", sa.String(length=64), nullable=True),
-        sa.Column("licencia", sa.String(length=64), nullable=True),
-        sa.Column("puesto", sa.String(length=64), nullable=True),
-        sa.Column("telefono", sa.String(length=32), nullable=True),
+        sa.Column("nombre", sa.String(length=160), nullable=False),
+        sa.Column("doc_id", sa.String(length=80), nullable=True),
+        sa.Column("licencia_vence", sa.Date(), nullable=True),
+        sa.Column("notas", sa.Text(), nullable=True),
         sa.Column(
-            "status",
+            "estatus",
             sa.String(length=32),
             nullable=True,
             server_default="activo",
         ),
-        sa.Column(
-            "fecha_alta",
-            sa.Date(),
-            nullable=True,
-            server_default=sa.func.current_date(),
-        ),
-        sa.Column(
-            "created_at",
-            sa.DateTime(),
-            nullable=True,
-            server_default=sa.func.now(),
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(),
-            nullable=True,
-            server_default=sa.func.now(),
-        ),
-        sa.UniqueConstraint("identificacion", name="uq_operadores_identificacion"),
     )
     op.create_index("ix_operadores_nombre", "operadores", ["nombre"])
 

--- a/tests/operadores/test_operadores_smoke.py
+++ b/tests/operadores/test_operadores_smoke.py
@@ -1,0 +1,14 @@
+def test_operadores_list(client, monkeypatch):
+    monkeypatch.setenv("DISABLE_SECURITY", "1")
+    response = client.get("/operadores/")
+    assert response.status_code in (200, 302)
+
+
+def test_operadores_create(client, monkeypatch):
+    monkeypatch.setenv("DISABLE_SECURITY", "1")
+    response = client.post(
+        "/operadores/new",
+        data={"nombre": "Juan Pérez", "doc_id": "LIC123"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)


### PR DESCRIPTION
## Summary
- replace the Operador model, migrations, and CLI seed data with the MVP fields and helpers
- rebuild the operadores blueprint, templates, and navigation links to support listing, CRUD, and CSV export
- add an export endpoint and button for equipos along with smoke tests for the operadores endpoints

## Testing
- `pytest tests/operadores/test_operadores_smoke.py` *(fails: ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_68dac4ad73a08326a65126147c0454e9