### PR TITLE
Add dashboard KPIs and chart visualizations

### DIFF
--- a/app/blueprints/dashboard/routes.py
+++ b/app/blueprints/dashboard/routes.py
@@ -1,71 +1,146 @@
-from flask import Blueprint, current_app, render_template
+from datetime import date, timedelta
+from flask import Blueprint, render_template, current_app
 from sqlalchemy import func
-
 from app.extensions import db
 
-bp = Blueprint(
-    "dashboard_bp",
-    __name__,
-    url_prefix="/dashboard",
-    template_folder="../../templates/dashboard",
-)
-
+bp = Blueprint("dashboard_bp", __name__, url_prefix="/dashboard", template_folder="../../templates/dashboard")
 
 @bp.before_request
 def _guard():
+    # En DEV no bloqueamos
     if current_app.config.get("SECURITY_DISABLED") or current_app.config.get("LOGIN_DISABLED"):
         return
 
+def _safe_imports():
+    # Importa modelos si existen (tolerante)
+    try:
+        from app.models.equipo import Equipo
+    except Exception:
+        try:
+            from app.models import Equipo
+        except Exception:
+            Equipo = None
+    try:
+        from app.models.operador import Operador
+    except Exception:
+        try:
+            from app.models import Operador
+        except Exception:
+            Operador = None
+    try:
+        from app.models.parte_diaria import ParteDiaria
+    except Exception:
+        ParteDiaria = None
+    try:
+        from app.models.checklist import ChecklistTemplate, ChecklistRun
+    except Exception:
+        ChecklistTemplate = ChecklistRun = None
+    try:
+        from app.models.parte_diaria import ArchivoAdjunto
+    except Exception:
+        try:
+            from app.models.archivo import ArchivoAdjunto
+        except Exception:
+            ArchivoAdjunto = None
+    return Equipo, Operador, ParteDiaria, ChecklistTemplate, ChecklistRun, ArchivoAdjunto
+
+def _date_list(days):
+    # últimos N días, ascendente
+    return [date.today() - timedelta(days=i) for i in range(days-1, -1, -1)]
 
 @bp.get("/")
 def index():
-    counts: dict[str, int | str] = {}
+    Equipo, Operador, ParteDiaria, ChecklistTemplate, ChecklistRun, ArchivoAdjunto = _safe_imports()
 
-    def safe_count(model, label: str) -> None:
+    # --------- KPIs (conteos) ---------
+    def _count(model):
         try:
-            counts[label] = db.session.query(func.count(model.id)).scalar() or 0
-        except Exception:  # pragma: no cover - conteo defensivo
-            counts[label] = "-"
+            return int(db.session.query(func.count(model.id)).scalar() or 0)
+        except Exception:
+            return "-"
 
-    try:
-        from app.models.equipo import Equipo
-    except Exception:  # pragma: no cover - fallback para apps sin módulo
-        from app.models import Equipo
+    counts = {
+        "equipos": _count(Equipo) if Equipo else "-",
+        "operadores": _count(Operador) if Operador else "-",
+        "partes": _count(ParteDiaria) if ParteDiaria else "-",
+        "plantillas": _count(ChecklistTemplate) if ChecklistTemplate else "-",
+        "checklist_runs": _count(ChecklistRun) if ChecklistRun else "-",
+        "archivos": _count(ArchivoAdjunto) if ArchivoAdjunto else "-",
+    }
 
-    try:
-        from app.models.operador import Operador
-    except Exception:  # pragma: no cover - fallback para apps sin módulo
-        from app.models import Operador
+    # --------- Series: últimos 14 días ---------
+    labels_14 = [d.isoformat() for d in _date_list(14)]
 
-    try:
-        from app.models.parte_diaria import ParteDiaria
-    except Exception:  # pragma: no cover - proyectos sin partes
-        ParteDiaria = None
+    horas_14 = [0.0] * 14
+    if ParteDiaria:
+        start14 = date.today() - timedelta(days=13)
+        rows = (db.session.query(ParteDiaria.fecha, func.coalesce(func.sum(ParteDiaria.horas_trabajo), 0.0))
+                .filter(ParteDiaria.fecha >= start14)
+                .group_by(ParteDiaria.fecha)
+                .order_by(ParteDiaria.fecha)
+                .all())
+        idx = {lab: i for i, lab in enumerate(labels_14)}
+        for f, s in rows:
+            k = f.isoformat()
+            if k in idx:
+                horas_14[idx[k]] = float(s or 0.0)
 
-    try:
-        from app.models.checklist import ChecklistRun, ChecklistTemplate
-    except Exception:  # pragma: no cover - proyectos sin checklists
-        ChecklistTemplate = ChecklistRun = None
+    pctok_14 = [0.0] * 14
+    if ChecklistRun:
+        start14 = date.today() - timedelta(days=13)
+        rows = (db.session.query(ChecklistRun.fecha, func.coalesce(func.avg(ChecklistRun.pct_ok), 0.0))
+                .filter(ChecklistRun.fecha >= start14)
+                .group_by(ChecklistRun.fecha)
+                .order_by(ChecklistRun.fecha)
+                .all())
+        idx = {lab: i for i, lab in enumerate(labels_14)}
+        for f, avgv in rows:
+            k = f.isoformat()
+            if k in idx:
+                pctok_14[idx[k]] = float(avgv or 0.0)
 
-    try:
-        from app.models.parte_diaria import ArchivoAdjunto
-    except Exception:  # pragma: no cover - apps con modelo alterno
-        try:
-            from app.models.archivo import ArchivoAdjunto
-        except Exception:  # pragma: no cover - sin archivos
-            ArchivoAdjunto = None
-
-    for model, label in [
-        (Equipo, "equipos"),
-        (Operador, "operadores"),
-        (ParteDiaria, "partes"),
-        (ChecklistTemplate, "plantillas"),
-        (ChecklistRun, "checklist_runs"),
-        (ArchivoAdjunto, "archivos"),
-    ]:
-        if model is not None:
-            safe_count(model, label)
+    # --------- Top 5 equipos por horas (30 días) ---------
+    top_labels, top_data = [], []
+    if ParteDiaria:
+        start30 = date.today() - timedelta(days=29)
+        if Equipo:
+            rows = (db.session.query(func.coalesce(Equipo.nombre, func.concat("Equipo #", Equipo.id)), func.sum(ParteDiaria.horas_trabajo))
+                    .join(Equipo, Equipo.id == ParteDiaria.equipo_id, isouter=True)
+                    .filter(ParteDiaria.fecha >= start30, ParteDiaria.equipo_id != None)
+                    .group_by(Equipo.id, Equipo.nombre)
+                    .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
+                    .limit(5).all())
         else:
-            counts[label] = "-"
+            rows = (db.session.query(ParteDiaria.equipo_id, func.sum(ParteDiaria.horas_trabajo))
+                    .filter(ParteDiaria.fecha >= start30, ParteDiaria.equipo_id != None)
+                    .group_by(ParteDiaria.equipo_id)
+                    .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
+                    .limit(5).all())
+            rows = [(f"Equipo #{eid or '-'}", s) for eid, s in rows]
+        for name, s in rows:
+            top_labels.append(str(name))
+            top_data.append(float(s or 0.0))
 
-    return render_template("dashboard/index.html", counts=counts)
+    # --------- Pie: partes con/ sin incidencias (30 días) ---------
+    incid_pie = [0, 0]  # [con_incid, sin_incid]
+    if ParteDiaria:
+        start30 = date.today() - timedelta(days=29)
+        total = (db.session.query(func.count(ParteDiaria.id))
+                 .filter(ParteDiaria.fecha >= start30).scalar() or 0)
+        con = (db.session.query(func.count(ParteDiaria.id))
+               .filter(ParteDiaria.fecha >= start30)
+               .filter(func.coalesce(func.nullif(func.trim(ParteDiaria.incidencias), ''), None) != None)
+               .scalar() or 0)
+        incid_pie = [int(con), int(total - con)]
+
+    # Render
+    return render_template(
+        "dashboard/index.html",
+        counts=counts,
+        labels_14=labels_14,
+        horas_14=horas_14,
+        pctok_14=pctok_14,
+        top_labels=top_labels,
+        top_data=top_data,
+        incid_pie=incid_pie,
+    )

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -1,22 +1,89 @@
 {% extends "layout.html" %}
 {% block content %}
 <h1>Dashboard (DEV)</h1>
-
 <p style="color:#888">Modo DEV: {{ 'ON' if DEV_MODE else 'OFF' }}</p>
 
+<!-- KPIs -->
 <div class="cards">
   <a class="card" href="{{ url_for('equipos_bp.index') }}">Equipos <b>{{ counts.get('equipos') }}</b></a>
   <a class="card" href="{{ url_for('operadores_bp.index') }}">Operadores <b>{{ counts.get('operadores') }}</b></a>
-  <a class="card" href="{{ url_for('partes.index') }}">Partes <b>{{ counts.get('partes') }}</b></a>
-  <a class="card" href="{{ url_for('partes.resumen') }}">Resumen Partes</a>
+  <a class="card" href="{{ url_for('partes_bp.index') }}">Partes <b>{{ counts.get('partes') }}</b></a>
   <a class="card" href="{{ url_for('checklists_bp.templates_index') }}">Plantillas <b>{{ counts.get('plantillas') }}</b></a>
   <a class="card" href="{{ url_for('checklists_bp.runs_index') }}">Ejecuciones <b>{{ counts.get('checklist_runs') }}</b></a>
+  <a class="card" href="{{ url_for('partes_bp.resumen') }}">Resumen Partes</a>
   <a class="card" href="{{ url_for('checklists_bp.resumen') }}">Resumen Checklists</a>
 </div>
 
+<hr>
+
+<!-- Gráficos -->
+<div class="grid">
+  <div class="cell">
+    <h3>Horas trabajadas (últimos 14 días)</h3>
+    <canvas id="chartHoras"></canvas>
+  </div>
+  <div class="cell">
+    <h3>% OK Checklists (últimos 14 días)</h3>
+    <canvas id="chartPctOk"></canvas>
+  </div>
+  <div class="cell">
+    <h3>Top 5 equipos por horas (30 días)</h3>
+    <canvas id="chartTopEquipos"></canvas>
+  </div>
+  <div class="cell">
+    <h3>Incidencias en partes (30 días)</h3>
+    <canvas id="chartIncid"></canvas>
+  </div>
+</div>
+
 <style>
-.cards{display:flex;gap:12px;flex-wrap:wrap}
+.cards{display:flex;gap:12px;flex-wrap:wrap;margin-bottom:12px}
 .card{border:1px solid #333;border-radius:8px;padding:12px 16px;text-decoration:none;color:#111}
 .card b{display:block;font-size:20px;margin-top:6px}
+.grid{display:grid;grid-template-columns:repeat(2,minmax(280px,1fr));gap:20px}
+.cell{background:#fafafa;border:1px solid #ddd;border-radius:8px;padding:12px}
+@media (max-width:900px){.grid{grid-template-columns:1fr}}
 </style>
+
+<!-- Chart.js (CDN) -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const labels14 = {{ labels_14|tojson }};
+const horas14 = {{ horas_14|tojson }};
+const pctok14 = {{ pctok_14|tojson }};
+const topLabels = {{ top_labels|tojson }};
+const topData = {{ top_data|tojson }};
+const incidPie = {{ incid_pie|tojson }};
+
+const el1 = document.getElementById('chartHoras').getContext('2d');
+new Chart(el1, {
+  type: 'line',
+  data: { labels: labels14, datasets: [{ label: 'Horas', data: horas14, tension: 0.25 }] },
+  options: { responsive: true, plugins: { legend: { display: true } }, scales: { y: { beginAtZero: true } } }
+});
+
+const el2 = document.getElementById('chartPctOk').getContext('2d');
+new Chart(el2, {
+  type: 'line',
+  data: { labels: labels14, datasets: [{ label: '% OK', data: pctok14, tension: 0.25 }] },
+  options: { responsive: true, plugins: { legend: { display: true } }, scales: { y: { suggestedMin: 0, suggestedMax: 100 } } }
+});
+
+const el3 = document.getElementById('chartTopEquipos').getContext('2d');
+new Chart(el3, {
+  type: 'bar',
+  data: { labels: topLabels, datasets: [{ label: 'Horas (30 días)', data: topData }] },
+  options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }
+});
+
+const el4 = document.getElementById('chartIncid').getContext('2d');
+new Chart(el4, {
+  type: 'doughnut',
+  data: {
+    labels: ['Con incidencias', 'Sin incidencias'],
+    datasets: [{ data: incidPie }]
+  },
+  options: { responsive: true, plugins: { legend: { position: 'bottom' } } }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the dashboard blueprint with aggregated KPIs and chart data builders
- update the dashboard template to render KPI cards and Chart.js visualizations

## Testing
- flask --app wsgi.py run --host=0.0.0.0 --port=5000

------
https://chatgpt.com/codex/tasks/task_e_68dad9ba146c8326b61c3228b4307852