### PR TITLE
Actualiza dashboard con selector de rango y exportaciones CSV

### DIFF
--- a/app/blueprints/dashboard/routes.py
+++ b/app/blueprints/dashboard/routes.py
@@ -1,18 +1,32 @@
+from __future__ import annotations
+
 from datetime import date, timedelta
-from flask import Blueprint, render_template, current_app
-from sqlalchemy import func
+from io import StringIO, BytesIO
+import csv
+
+from flask import Blueprint, render_template, current_app, request, send_file
+from sqlalchemy import func, case
+
 from app.extensions import db
 
-bp = Blueprint("dashboard_bp", __name__, url_prefix="/dashboard", template_folder="../../templates/dashboard")
+bp = Blueprint(
+    "dashboard_bp",
+    __name__,
+    url_prefix="/dashboard",
+    template_folder="../../templates/dashboard",
+)
 
 @bp.before_request
 def _guard():
-    # En DEV no bloqueamos
+    # En DEV no bloqueamos; cuando reactivemos seguridad se puede exigir login aquí.
     if current_app.config.get("SECURITY_DISABLED") or current_app.config.get("LOGIN_DISABLED"):
         return
 
+
+# -------- Utilidades --------
+
 def _safe_imports():
-    # Importa modelos si existen (tolerante)
+    """Importa modelos de forma tolerante (para que el dashboard no truene si falta alguno)."""
     try:
         from app.models.equipo import Equipo
     except Exception:
@@ -20,6 +34,7 @@ def _safe_imports():
             from app.models import Equipo
         except Exception:
             Equipo = None
+
     try:
         from app.models.operador import Operador
     except Exception:
@@ -27,14 +42,17 @@ def _safe_imports():
             from app.models import Operador
         except Exception:
             Operador = None
+
     try:
         from app.models.parte_diaria import ParteDiaria
     except Exception:
         ParteDiaria = None
+
     try:
         from app.models.checklist import ChecklistTemplate, ChecklistRun
     except Exception:
         ChecklistTemplate = ChecklistRun = None
+
     try:
         from app.models.parte_diaria import ArchivoAdjunto
     except Exception:
@@ -42,17 +60,31 @@ def _safe_imports():
             from app.models.archivo import ArchivoAdjunto
         except Exception:
             ArchivoAdjunto = None
+
     return Equipo, Operador, ParteDiaria, ChecklistTemplate, ChecklistRun, ArchivoAdjunto
 
-def _date_list(days):
-    # últimos N días, ascendente
-    return [date.today() - timedelta(days=i) for i in range(days-1, -1, -1)]
+
+def _date_list(days: int):
+    """Devuelve lista de fechas (date) para últimos N días en orden ascendente."""
+    return [date.today() - timedelta(days=i) for i in range(days - 1, -1, -1)]
+
+
+def _valid_days(raw) -> int:
+    try:
+        d = int(raw)
+    except Exception:
+        return 14
+    return d if d in (7, 14, 30, 60, 90) else 14
+
+
+# -------- Vista principal --------
 
 @bp.get("/")
 def index():
     Equipo, Operador, ParteDiaria, ChecklistTemplate, ChecklistRun, ArchivoAdjunto = _safe_imports()
+    days = _valid_days(request.args.get("days", 14))
 
-    # --------- KPIs (conteos) ---------
+    # KPIs base
     def _count(model):
         try:
             return int(db.session.query(func.count(model.id)).scalar() or 0)
@@ -68,79 +100,302 @@ def index():
         "archivos": _count(ArchivoAdjunto) if ArchivoAdjunto else "-",
     }
 
-    # --------- Series: últimos 14 días ---------
-    labels_14 = [d.isoformat() for d in _date_list(14)]
+    # KPIs de licencias (on-the-fly, sin cron)
+    lic_por_vencer_30 = "-"
+    lic_vencidas = "-"
+    if Operador:
+        hoy = date.today()
+        lim = hoy + timedelta(days=30)
+        lic_vencidas = (
+            db.session.query(func.count(Operador.id))
+            .filter(Operador.licencia_vence != None, Operador.licencia_vence < hoy)
+            .scalar()
+            or 0
+        )
+        lic_por_vencer_30 = (
+            db.session.query(func.count(Operador.id))
+            .filter(
+                Operador.licencia_vence != None,
+                Operador.licencia_vence >= hoy,
+                Operador.licencia_vence <= lim,
+            )
+            .scalar()
+            or 0
+        )
 
-    horas_14 = [0.0] * 14
+    counts["lic_por_vencer_30"] = lic_por_vencer_30 if lic_por_vencer_30 == "-" else int(lic_por_vencer_30)
+    counts["lic_vencidas"] = lic_vencidas if lic_vencidas == "-" else int(lic_vencidas)
+
+    # Series por rango seleccionado
+    labels = [d.isoformat() for d in _date_list(days)]
+
+    horas_series = [0.0] * days
     if ParteDiaria:
-        start14 = date.today() - timedelta(days=13)
-        rows = (db.session.query(ParteDiaria.fecha, func.coalesce(func.sum(ParteDiaria.horas_trabajo), 0.0))
-                .filter(ParteDiaria.fecha >= start14)
-                .group_by(ParteDiaria.fecha)
-                .order_by(ParteDiaria.fecha)
-                .all())
-        idx = {lab: i for i, lab in enumerate(labels_14)}
+        start = date.today() - timedelta(days=days - 1)
+        rows = (
+            db.session.query(ParteDiaria.fecha, func.coalesce(func.sum(ParteDiaria.horas_trabajo), 0.0))
+            .filter(ParteDiaria.fecha >= start)
+            .group_by(ParteDiaria.fecha)
+            .order_by(ParteDiaria.fecha)
+            .all()
+        )
+        idx = {lab: i for i, lab in enumerate(labels)}
         for f, s in rows:
             k = f.isoformat()
             if k in idx:
-                horas_14[idx[k]] = float(s or 0.0)
+                horas_series[idx[k]] = float(s or 0.0)
 
-    pctok_14 = [0.0] * 14
+    pctok_series = [0.0] * days
     if ChecklistRun:
-        start14 = date.today() - timedelta(days=13)
-        rows = (db.session.query(ChecklistRun.fecha, func.coalesce(func.avg(ChecklistRun.pct_ok), 0.0))
-                .filter(ChecklistRun.fecha >= start14)
-                .group_by(ChecklistRun.fecha)
-                .order_by(ChecklistRun.fecha)
-                .all())
-        idx = {lab: i for i, lab in enumerate(labels_14)}
+        start = date.today() - timedelta(days=days - 1)
+        rows = (
+            db.session.query(ChecklistRun.fecha, func.coalesce(func.avg(ChecklistRun.pct_ok), 0.0))
+            .filter(ChecklistRun.fecha >= start)
+            .group_by(ChecklistRun.fecha)
+            .order_by(ChecklistRun.fecha)
+            .all()
+        )
+        idx = {lab: i for i, lab in enumerate(labels)}
         for f, avgv in rows:
             k = f.isoformat()
             if k in idx:
-                pctok_14[idx[k]] = float(avgv or 0.0)
+                pctok_series[idx[k]] = float(avgv or 0.0)
 
-    # --------- Top 5 equipos por horas (30 días) ---------
+    # Top 5 equipos por horas (usa el mismo rango)
     top_labels, top_data = [], []
     if ParteDiaria:
-        start30 = date.today() - timedelta(days=29)
+        start = date.today() - timedelta(days=days - 1)
         if Equipo:
-            rows = (db.session.query(func.coalesce(Equipo.nombre, func.concat("Equipo #", Equipo.id)), func.sum(ParteDiaria.horas_trabajo))
-                    .join(Equipo, Equipo.id == ParteDiaria.equipo_id, isouter=True)
-                    .filter(ParteDiaria.fecha >= start30, ParteDiaria.equipo_id != None)
-                    .group_by(Equipo.id, Equipo.nombre)
-                    .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
-                    .limit(5).all())
+            rows = (
+                db.session.query(
+                    func.coalesce(Equipo.nombre, func.concat("Equipo #", Equipo.id)),
+                    func.sum(ParteDiaria.horas_trabajo),
+                )
+                .join(Equipo, Equipo.id == ParteDiaria.equipo_id, isouter=True)
+                .filter(ParteDiaria.fecha >= start, ParteDiaria.equipo_id != None)
+                .group_by(Equipo.id, Equipo.nombre)
+                .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
+                .limit(5)
+                .all()
+            )
         else:
-            rows = (db.session.query(ParteDiaria.equipo_id, func.sum(ParteDiaria.horas_trabajo))
-                    .filter(ParteDiaria.fecha >= start30, ParteDiaria.equipo_id != None)
-                    .group_by(ParteDiaria.equipo_id)
-                    .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
-                    .limit(5).all())
+            rows = (
+                db.session.query(ParteDiaria.equipo_id, func.sum(ParteDiaria.horas_trabajo))
+                .filter(ParteDiaria.fecha >= start, ParteDiaria.equipo_id != None)
+                .group_by(ParteDiaria.equipo_id)
+                .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
+                .limit(5)
+                .all()
+            )
             rows = [(f"Equipo #{eid or '-'}", s) for eid, s in rows]
+
         for name, s in rows:
             top_labels.append(str(name))
             top_data.append(float(s or 0.0))
 
-    # --------- Pie: partes con/ sin incidencias (30 días) ---------
-    incid_pie = [0, 0]  # [con_incid, sin_incid]
+    # Pie incidencias (con/sin) en el rango
+    incid_pie = [0, 0]
     if ParteDiaria:
-        start30 = date.today() - timedelta(days=29)
-        total = (db.session.query(func.count(ParteDiaria.id))
-                 .filter(ParteDiaria.fecha >= start30).scalar() or 0)
-        con = (db.session.query(func.count(ParteDiaria.id))
-               .filter(ParteDiaria.fecha >= start30)
-               .filter(func.coalesce(func.nullif(func.trim(ParteDiaria.incidencias), ''), None) != None)
-               .scalar() or 0)
+        start = date.today() - timedelta(days=days - 1)
+        total = (
+            db.session.query(func.count(ParteDiaria.id))
+            .filter(ParteDiaria.fecha >= start)
+            .scalar()
+            or 0
+        )
+        con = (
+            db.session.query(func.count(ParteDiaria.id))
+            .filter(ParteDiaria.fecha >= start)
+            .filter(
+                func.coalesce(func.nullif(func.trim(ParteDiaria.incidencias), ""), None) != None
+            )
+            .scalar()
+            or 0
+        )
         incid_pie = [int(con), int(total - con)]
 
     # Render
     return render_template(
         "dashboard/index.html",
         counts=counts,
-        labels_14=labels_14,
-        horas_14=horas_14,
-        pctok_14=pctok_14,
+        labels_14=labels,       # reutilizamos nombres de la plantilla existente
+        horas_14=horas_series,
+        pctok_14=pctok_series,
         top_labels=top_labels,
         top_data=top_data,
         incid_pie=incid_pie,
+        days=days,
+    )
+
+
+# --------- Exports CSV ---------
+
+def _csv_bytes(rows, header):
+    buf = StringIO()
+    w = csv.writer(buf)
+    w.writerow(header)
+    for r in rows:
+        w.writerow(r)
+    data = buf.getvalue().encode("utf-8")
+    return BytesIO(data)
+
+
+@bp.get("/export/kpis.csv")
+def export_kpis():
+    Equipo, Operador, ParteDiaria, ChecklistTemplate, ChecklistRun, ArchivoAdjunto = _safe_imports()
+
+    def _count(m):
+        try:
+            return int(db.session.query(func.count(m.id)).scalar() or 0)
+        except Exception:
+            return 0
+
+    rows = [
+        ("equipos", _count(Equipo) if Equipo else 0),
+        ("operadores", _count(Operador) if Operador else 0),
+        ("partes", _count(ParteDiaria) if ParteDiaria else 0),
+        ("plantillas", _count(ChecklistTemplate) if ChecklistTemplate else 0),
+        ("checklist_runs", _count(ChecklistRun) if ChecklistRun else 0),
+        ("archivos", _count(ArchivoAdjunto) if ArchivoAdjunto else 0),
+    ]
+    bio = _csv_bytes(rows, ["kpi", "valor"])
+    return send_file(bio, as_attachment=True, download_name="dashboard_kpis.csv", mimetype="text/csv")
+
+
+@bp.get("/export/series.csv")
+def export_series():
+    metric = request.args.get("metric", "horas")  # 'horas' | 'pctok'
+    days = _valid_days(request.args.get("days", 14))
+    _, _, ParteDiaria, _, ChecklistRun, _ = _safe_imports()
+    labels = [d.isoformat() for d in _date_list(days)]
+    rows = []
+
+    if metric == "horas" and ParteDiaria:
+        start = date.today() - timedelta(days=days - 1)
+        data = {lab: 0.0 for lab in labels}
+        q = (
+            db.session.query(ParteDiaria.fecha, func.coalesce(func.sum(ParteDiaria.horas_trabajo), 0.0))
+            .filter(ParteDiaria.fecha >= start)
+            .group_by(ParteDiaria.fecha)
+            .all()
+        )
+        for f, s in q:
+            data[f.isoformat()] = float(s or 0.0)
+        rows = [(k, data[k]) for k in labels]
+
+    elif metric == "pctok" and ChecklistRun:
+        start = date.today() - timedelta(days=days - 1)
+        data = {lab: 0.0 for lab in labels}
+        q = (
+            db.session.query(ChecklistRun.fecha, func.coalesce(func.avg(ChecklistRun.pct_ok), 0.0))
+            .filter(ChecklistRun.fecha >= start)
+            .group_by(ChecklistRun.fecha)
+            .all()
+        )
+        for f, s in q:
+            data[f.isoformat()] = float(s or 0.0)
+        rows = [(k, data[k]) for k in labels]
+
+    else:
+        rows = [(lab, 0) for lab in labels]
+
+    bio = _csv_bytes(rows, ["fecha", metric])
+    return send_file(
+        bio,
+        as_attachment=True,
+        download_name=f"series_{metric}_{days}d.csv",
+        mimetype="text/csv",
+    )
+
+
+@bp.get("/export/top_equipos.csv")
+def export_top_equipos():
+    days = _valid_days(request.args.get("days", 14))
+    Equipo, _, ParteDiaria, *_ = _safe_imports()
+    start = date.today() - timedelta(days=days - 1)
+    rows = []
+
+    if ParteDiaria:
+        if Equipo:
+            q = (
+                db.session.query(
+                    func.coalesce(Equipo.nombre, func.concat("Equipo #", Equipo.id)),
+                    func.sum(ParteDiaria.horas_trabajo),
+                )
+                .join(Equipo, Equipo.id == ParteDiaria.equipo_id, isouter=True)
+                .filter(ParteDiaria.fecha >= start, ParteDiaria.equipo_id != None)
+                .group_by(Equipo.id, Equipo.nombre)
+                .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
+                .limit(5)
+                .all()
+            )
+        else:
+            q = (
+                db.session.query(ParteDiaria.equipo_id, func.sum(ParteDiaria.horas_trabajo))
+                .filter(ParteDiaria.fecha >= start, ParteDiaria.equipo_id != None)
+                .group_by(ParteDiaria.equipo_id)
+                .order_by(func.sum(ParteDiaria.horas_trabajo).desc())
+                .limit(5)
+                .all()
+            )
+            q = [(f"Equipo #{eid or '-'}", s) for eid, s in q]
+
+        rows = [(name, float(s or 0.0)) for name, s in q]
+
+    bio = _csv_bytes(rows, ["equipo", "horas"])
+    return send_file(
+        bio,
+        as_attachment=True,
+        download_name=f"top_equipos_{days}d.csv",
+        mimetype="text/csv",
+    )
+
+
+@bp.get("/export/incidencias.csv")
+def export_incidencias():
+    days = _valid_days(request.args.get("days", 14))
+    _, _, ParteDiaria, *_ = _safe_imports()
+    start = date.today() - timedelta(days=days - 1)
+    rows = []
+
+    if ParteDiaria:
+        q = (
+            db.session.query(
+                ParteDiaria.fecha,
+                func.sum(
+                    case(
+                        (
+                            func.coalesce(
+                                func.nullif(func.trim(ParteDiaria.incidencias), ""), None
+                            )
+                            != None,
+                            1,
+                        ),
+                        else_=0,
+                    )
+                ),
+                func.count(ParteDiaria.id),
+            )
+            .filter(ParteDiaria.fecha >= start)
+            .group_by(ParteDiaria.fecha)
+            .order_by(ParteDiaria.fecha)
+            .all()
+        )
+        # fecha, con_incidencias, total, sin_incidencias
+        for f, con, tot in q:
+            rows.append(
+                (
+                    f.isoformat(),
+                    int(con or 0),
+                    int(tot or 0),
+                    int((tot or 0) - (con or 0)),
+                )
+            )
+
+    bio = _csv_bytes(rows, ["fecha", "con_incidencias", "total", "sin_incidencias"])
+    return send_file(
+        bio,
+        as_attachment=True,
+        download_name=f"incidencias_{days}d.csv",
+        mimetype="text/csv",
     )

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -12,26 +12,50 @@
   <a class="card" href="{{ url_for('checklists_bp.runs_index') }}">Ejecuciones <b>{{ counts.get('checklist_runs') }}</b></a>
   <a class="card" href="{{ url_for('partes_bp.resumen') }}">Resumen Partes</a>
   <a class="card" href="{{ url_for('checklists_bp.resumen') }}">Resumen Checklists</a>
+  <!-- Accesos rápidos de licencias -->
+  <a class="card" href="{{ url_for('operadores_bp.index', vence_en=30) }}">
+    Licencias por vencer (30d) <b>{{ counts.get('lic_por_vencer_30') }}</b>
+  </a>
+  <a class="card" href="{{ url_for('operadores_bp.index', vencidas=1) }}">
+    Licencias vencidas <b>{{ counts.get('lic_vencidas') }}</b>
+  </a>
 </div>
+
+<form method="get" action="{{ url_for('dashboard_bp.index') }}" class="mb-2">
+  <label>Rango: </label>
+  <select name="days" onchange="this.form.submit()">
+    {% for d in [7,14,30,60,90] %}
+      <option value="{{ d }}" {% if days==d %}selected{% endif %}>{{ d }} días</option>
+    {% endfor %}
+  </select>
+  <a href="{{ url_for('dashboard_bp.export_kpis') }}">CSV KPIs</a>
+</form>
 
 <hr>
 
-<!-- Gráficos -->
 <div class="grid">
   <div class="cell">
-    <h3>Horas trabajadas (últimos 14 días)</h3>
+    <h3>Horas trabajadas ({{ days }} días)
+      <small><a href="{{ url_for('dashboard_bp.export_series', metric='horas', days=days) }}">CSV</a></small>
+    </h3>
     <canvas id="chartHoras"></canvas>
   </div>
   <div class="cell">
-    <h3>% OK Checklists (últimos 14 días)</h3>
+    <h3>% OK Checklists ({{ days }} días)
+      <small><a href="{{ url_for('dashboard_bp.export_series', metric='pctok', days=days) }}">CSV</a></small>
+    </h3>
     <canvas id="chartPctOk"></canvas>
   </div>
   <div class="cell">
-    <h3>Top 5 equipos por horas (30 días)</h3>
+    <h3>Top 5 equipos por horas ({{ days }} días)
+      <small><a href="{{ url_for('dashboard_bp.export_top_equipos', days=days) }}">CSV</a></small>
+    </h3>
     <canvas id="chartTopEquipos"></canvas>
   </div>
   <div class="cell">
-    <h3>Incidencias en partes (30 días)</h3>
+    <h3>Incidencias en partes ({{ days }} días)
+      <small><a href="{{ url_for('dashboard_bp.export_incidencias', days=days) }}">CSV</a></small>
+    </h3>
     <canvas id="chartIncid"></canvas>
   </div>
 </div>
@@ -41,49 +65,38 @@
 .card{border:1px solid #333;border-radius:8px;padding:12px 16px;text-decoration:none;color:#111}
 .card b{display:block;font-size:20px;margin-top:6px}
 .grid{display:grid;grid-template-columns:repeat(2,minmax(280px,1fr));gap:20px}
-.cell{background:#fafafa;border:1px solid #ddd;border-radius:8px;padding:12px}
+.cell{background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:12px}
 @media (max-width:900px){.grid{grid-template-columns:1fr}}
 </style>
 
-<!-- Chart.js (CDN) -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 const labels14 = {{ labels_14|tojson }};
-const horas14 = {{ horas_14|tojson }};
-const pctok14 = {{ pctok_14|tojson }};
+const horas14  = {{ horas_14|tojson }};
+const pctok14  = {{ pctok_14|tojson }};
 const topLabels = {{ top_labels|tojson }};
-const topData = {{ top_data|tojson }};
-const incidPie = {{ incid_pie|tojson }};
+const topData   = {{ top_data|tojson }};
+const incidPie  = {{ incid_pie|tojson }};
 
-const el1 = document.getElementById('chartHoras').getContext('2d');
-new Chart(el1, {
+new Chart(document.getElementById('chartHoras').getContext('2d'), {
   type: 'line',
   data: { labels: labels14, datasets: [{ label: 'Horas', data: horas14, tension: 0.25 }] },
-  options: { responsive: true, plugins: { legend: { display: true } }, scales: { y: { beginAtZero: true } } }
+  options: { responsive:true, plugins:{ legend:{ display:true } }, scales:{ y:{ beginAtZero:true } } }
 });
-
-const el2 = document.getElementById('chartPctOk').getContext('2d');
-new Chart(el2, {
+new Chart(document.getElementById('chartPctOk').getContext('2d'), {
   type: 'line',
   data: { labels: labels14, datasets: [{ label: '% OK', data: pctok14, tension: 0.25 }] },
-  options: { responsive: true, plugins: { legend: { display: true } }, scales: { y: { suggestedMin: 0, suggestedMax: 100 } } }
+  options: { responsive:true, plugins:{ legend:{ display:true } }, scales:{ y:{ suggestedMin:0, suggestedMax:100 } } }
 });
-
-const el3 = document.getElementById('chartTopEquipos').getContext('2d');
-new Chart(el3, {
+new Chart(document.getElementById('chartTopEquipos').getContext('2d'), {
   type: 'bar',
-  data: { labels: topLabels, datasets: [{ label: 'Horas (30 días)', data: topData }] },
-  options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }
+  data: { labels: topLabels, datasets: [{ label: 'Horas', data: topData }] },
+  options: { responsive:true, plugins:{ legend:{ display:false } }, scales:{ y:{ beginAtZero:true } } }
 });
-
-const el4 = document.getElementById('chartIncid').getContext('2d');
-new Chart(el4, {
+new Chart(document.getElementById('chartIncid').getContext('2d'), {
   type: 'doughnut',
-  data: {
-    labels: ['Con incidencias', 'Sin incidencias'],
-    datasets: [{ data: incidPie }]
-  },
-  options: { responsive: true, plugins: { legend: { position: 'bottom' } } }
+  data: { labels: ['Con incidencias', 'Sin incidencias'], datasets: [{ data: incidPie }] },
+  options: { responsive:true, plugins:{ legend:{ position:'bottom' } } }
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- reemplaza la vista del dashboard para soportar selector de rango de 7/14/30/60/90 días y mostrar KPIs de licencias
- agrega exportaciones CSV para KPIs, series, top de equipos e incidencias
- actualiza la plantilla del dashboard con accesos rápidos, controles de rango y nuevos gráficos

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daeef187108326b69148e40bde9bca