### PR TITLE
Add theme toggle with CSS variables

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1,48 +1,11 @@
-a { text-decoration:none; }
-.sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
-
-.navbar{
-  position:sticky;top:0;z-index:10;
-  display:flex;align-items:center;justify-content:space-between;
-  padding:12px 18px;border-bottom:1px solid var(--border, #223454);
-  background:rgba(11,18,32,0.85);backdrop-filter:blur(6px)
-}
-.nav-left .brand{
-  display:inline-flex;align-items:center;gap:10px;
-  font-weight:600;letter-spacing:.3px
-}
-.nav-left .brand .logo{
-  height:24px;width:auto;display:block;border-radius:4px;
-  box-shadow:0 0 0 1px rgba(255,255,255,.06);
-}
-
-.nav-right{display:flex;gap:10px}
-.btn{
-  padding:8px 14px;border-radius:10px;
-  background:var(--accent, #33b1ff);color:#001726;font-weight:600;
-  border:1px solid transparent;transition:.2s
-}
-.btn:hover{filter:brightness(1.05)}
-.btn.outline{
-  background:transparent;border-color:var(--border, #223454);color:var(--text, #e8eefb)
-}
-.btn.outline:hover{background:rgba(18,26,42,.6)}
-
-.hero h1 { font-size:28px; margin-bottom:4px; }
-.about { margin-top:28px; }
-.external-link { display:inline-block; margin-top:10px; color:#33b1ff; font-weight:600; }
-.external-link:hover { text-decoration:underline; }
-
-.footer { margin:28px auto; text-align:center; color:#9fb2d0; }
-
-.auth-wrap{
-  max-width:640px;margin:48px auto;padding:24px;
-  background:rgba(20,30,49,.6);border:1px solid var(--border,#223454);border-radius:12px
-}
-.auth-wrap h1{margin:0 0 16px;font-size:24px}
-/* ci: touch for PR test */
-
+/* ===== Theme variables (dark default) ===== */
 :root{
+  --bg:#0b0f14;
+  --panel:#0f1520;
+  --border:#202938;
+  --text:#e5e7eb;
+  --muted:#9ca3af;
+  --accent:#33b1ff;
   --gap:12px;
   --gap-lg:16px;
   --radius:12px;
@@ -50,110 +13,182 @@ a { text-decoration:none; }
   --fw:600;
 }
 
+[data-theme='light']{
+  --bg:#f8fafc;
+  --panel:#ffffff;
+  --border:#e5e7eb;
+  --text:#0f172a;
+  --muted:#6b7280;
+  --accent:#0f62fe;
+}
+
+html{color-scheme:light dark;}
+html,body{height:100%;}
 *{box-sizing:border-box;}
 
-.btn, button, input[type="submit"]{
-  display:inline-flex; align-items:center; justify-content:center;
-  height:var(--btn-h); padding:0 14px; gap:8px;
-  border-radius:var(--radius); font-weight:var(--fw);
-  line-height:1; text-decoration:none; cursor:pointer;
+body{
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font-family:system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif;
+  line-height:1.5;
 }
 
-.btn-primary{ background:#24a0ff; color:#09111f; border:1px solid transparent; }
-.btn-outline{ background:transparent; color:#cfe8ff; border:1px solid #2b3a50; }
-.btn-danger{ background:#ef4444; color:#fff; border:1px solid transparent; }
-.btn-ghost{ background:transparent; color:#cfe8ff; border:1px solid transparent; }
+a{text-decoration:none;}
+.sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;}
 
-.btn-group{ display:flex; flex-wrap:wrap; gap:var(--gap); align-items:center; }
-.btn-group form{ display:flex; flex-wrap:wrap; gap:var(--gap); align-items:center; }
-.btn-wide{ min-width:132px; }
-.btn-sm{ height:36px; padding:0 12px; }
-.btn-block{ width:100%; }
+.navbar{
+  position:sticky;
+  top:0;
+  z-index:10;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:12px 18px;
+  border-bottom:1px solid var(--border);
+  background:var(--panel);
+  backdrop-filter:blur(6px);
+}
+
+.nav-left .brand{display:inline-flex; align-items:center; gap:10px; font-weight:600; letter-spacing:.3px;}
+.nav-left .brand .logo{height:24px; width:auto; display:block; border-radius:4px; box-shadow:0 0 0 1px rgba(255,255,255,.06);}
+
+.nav-right{display:flex; gap:10px; align-items:center;}
+
+.btn,
+button,
+input[type="submit"]{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:8px;
+  height:var(--btn-h);
+  padding:0 14px;
+  border-radius:var(--radius);
+  font-weight:var(--fw);
+  line-height:1;
+  text-decoration:none;
+  cursor:pointer;
+  border:1px solid var(--border);
+  background:var(--panel);
+  color:var(--text);
+  transition:filter .2s ease, background .2s ease, border-color .2s ease;
+}
+
+.btn:hover,
+button:hover,
+input[type="submit"]:hover{filter:brightness(1.05);}
+
+.btn-primary{background:var(--accent); color:#001726; border-color:var(--accent);}
+.btn-outline{background:transparent; color:var(--text); border-color:var(--border);}
+.btn-danger{background:#ef4444; color:#fff; border-color:#ef4444;}
+.btn-ghost{background:transparent; color:var(--text); border-color:transparent;}
+
+.btn-group{display:flex; flex-wrap:wrap; gap:var(--gap); align-items:center;}
+.btn-group form{display:flex; flex-wrap:wrap; gap:var(--gap); align-items:center;}
+.btn-wide{min-width:132px;}
+.btn-sm{height:36px; padding:0 12px;}
+.btn-block{width:100%;}
 
 input[type="text"],input[type="email"],input[type="date"],select,textarea{
-  border:1px solid #2b3a50; background:#0f1725; color:#dbe8ff;
-  border-radius:var(--radius); padding:10px 12px; height:var(--btn-h);
+  border:1px solid var(--border);
+  background:var(--panel);
+  color:var(--text);
+  border-radius:var(--radius);
+  padding:10px 12px;
+  height:var(--btn-h);
 }
-textarea{ min-height:var(--btn-h); height:auto; }
 
-.btn svg{ width:18px; height:18px; }
-.btn span{ display:inline-flex; align-items:center; }
+textarea{min-height:var(--btn-h); height:auto;}
 
-.icon{ display:block; }
+.btn svg{width:18px; height:18px;}
+.btn span{display:inline-flex; align-items:center;}
 
-:focus-visible{ outline:2px solid rgba(36,160,255,0.9); outline-offset:2px; }
+.icon{display:block;}
+
+:focus-visible{outline:2px solid rgba(36,160,255,0.9); outline-offset:2px;}
 .btn:focus-visible,
 button:focus-visible,
 input[type="submit"]:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
-input:focus-visible{
-  box-shadow:0 0 0 3px rgba(36,160,255,0.35);
+input:focus-visible{box-shadow:0 0 0 3px rgba(36,160,255,0.35);}
+
+.toolbar{display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap;}
+.inline{display:inline;}
+.toolbar form.inline{margin:0;}
+.stack-v{display:flex; flex-direction:column; gap:var(--gap);}
+.stack-h{display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap;}
+
+/* ===== Compact layout (ya usado por el dashboard) ===== */
+.container{max-width:1120px; margin:0 auto; padding:16px;}
+.page-title{font-size:22px; margin:6px 0 12px; font-weight:700;}
+.section{margin:10px 0 18px;}
+.muted{color:var(--muted);}
+
+.cards{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:var(--gap); margin:8px 0 12px;}
+.card{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); padding:10px 12px; text-decoration:none; color:inherit; transition:transform .05s ease, border-color .2s ease;}
+.card:hover{transform:translateY(-1px); border-color:#334155;}
+.card b{display:block; font-size:18px; margin-top:4px;}
+
+.grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:var(--gap);}
+.cell{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); padding:10px 12px;}
+.cell h3{font-size:16px; margin:0 0 8px; font-weight:600;}
+
+.canvas-wrap{height:220px;}
+.canvas-wrap canvas{width:100%!important; height:100%!important;}
+
+img,svg,canvas,video{max-width:100%; height:auto;}
+
+/* Portada: limita la imagen grande (siglo21) */
+.hero-img{max-height:220px; width:100%; object-fit:contain; display:block; margin:10px auto;}
+
+/* ===== Theme toggle ===== */
+.theme-toggle{position:fixed; right:16px; bottom:16px; z-index:1000; opacity:.9;}
+.theme-toggle:hover{opacity:1;}
+
+/* Additional UI elements */
+.hero h1{font-size:28px; margin-bottom:4px;}
+.about{margin-top:28px;}
+.external-link{display:inline-block; margin-top:10px; color:var(--accent); font-weight:600;}
+.external-link:hover{text-decoration:underline;}
+
+.footer{margin:28px auto; text-align:center; color:var(--muted);}
+
+.auth-wrap{
+  max-width:640px;
+  margin:48px auto;
+  padding:24px;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:12px;
 }
-.toolbar{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }
-.inline{ display:inline; }
-.toolbar form.inline{ margin:0; }
-.stack-v{ display:flex; flex-direction:column; gap:var(--gap); }
-.stack-h{ display:flex; gap:var(--gap); align-items:center; flex-wrap:wrap; }
+
+.auth-wrap h1{margin:0 0 16px; font-size:24px;}
 
 /* Grid de “tabla” utilizada en Admin/Usuarios */
-.table-grid{ display:grid; gap:var(--gap); align-items:center; }
-.table-grid.header-6{ grid-template-columns: 1.4fr .8fr .6fr 1fr 1fr 1.2fr; }
-.table-grid > .th{ font-weight:var(--fw); opacity:.85; }
-.table-grid .row{ display:contents; }
+.table-grid{display:grid; gap:var(--gap); align-items:center;}
+.table-grid.header-6{grid-template-columns:1.4fr .8fr .6fr 1fr 1fr 1.2fr;}
+.table-grid > .th{font-weight:var(--fw); opacity:.85;}
+.table-grid .row{display:contents;}
 
 /* Formularios horizontales (Bitácoras) */
 .form-grid{
   display:grid;
-  grid-template-columns: 220px 220px 180px minmax(280px,1fr) 160px;
-  gap:var(--gap); align-items:center;
+  grid-template-columns:220px 220px 180px minmax(280px,1fr) 160px;
+  gap:var(--gap);
+  align-items:center;
 }
 
 @media (max-width: 900px){
-  .table-grid.header-6{ grid-template-columns:1fr; }
-  .form-grid{ grid-template-columns:1fr; }
-  .btn-wide{ width:100%; }
-}
-/* ===== Compact Global Layout ===== */
-:root{
-  --bg:#0b0f14; --panel:#0f1520; --border:#202938; --text:#e5e7eb; --muted:#9ca3af;
-  --radius:12px; --gap:12px;
+  .table-grid.header-6{grid-template-columns:1fr;}
+  .form-grid{grid-template-columns:1fr;}
+  .btn-wide{width:100%;}
 }
 
-*{box-sizing:border-box}
-html,body{height:100%}
-body{
-  margin:0;
-  background:var(--bg); color:var(--text);
-  font-family:system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, sans-serif;
-  line-height:1.5;
-}
+.table{width:100%; border-collapse:collapse;}
+.table th,.table td{padding:8px 10px; border-bottom:1px solid var(--border);}
+.table th{text-align:left; color:var(--muted); font-weight:600;}
 
-.container{max-width:1120px; margin:0 auto; padding:16px}
-.page-title{font-size:22px; margin:6px 0 12px; font-weight:700}
-.section{margin:10px 0 18px}
-.muted{color:var(--muted)}
-
-.cards{display:grid; grid-template-columns:repeat(auto-fill,minmax(190px,1fr)); gap:var(--gap); margin:8px 0 12px}
-.card{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); padding:10px 12px; text-decoration:none; color:inherit; transition:transform .05s ease, border-color .2s ease}
-.card:hover{transform:translateY(-1px); border-color:#334155}
-.card b{display:block; font-size:18px; margin-top:4px}
-
-.grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:var(--gap)}
-.cell{background:var(--panel); border:1px solid var(--border); border-radius:var(--radius); padding:10px 12px}
-.cell h3{font-size:16px; margin:0 0 8px; font-weight:600}
-
-.canvas-wrap{height:220px}
-.canvas-wrap canvas{width:100%!important; height:100%!important}
-
-img,svg,canvas,video{max-width:100%; height:auto}
-
-/* ===== Home hero image (siglo21) ===== */
-.hero-img{max-height:220px; width:100%; object-fit:contain; display:block; margin:10px auto}
-
-.table{width:100%; border-collapse:collapse}
-.table th,.table td{padding:8px 10px; border-bottom:1px solid var(--border)}
-.table th{text-align:left; color:var(--muted); font-weight:600}
-
-header .nav a{padding:6px 8px; border-radius:8px}
-header .nav a.active{background:#111827}
+header .nav a{padding:6px 8px; border-radius:8px;}
+header .nav a.active{background:#111827;}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="es" data-theme="">
 {% import "_icons.html" as i %}
 {% import "_forms.html" as forms %}
 <head>
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body>
+  <button id="theme-toggle" class="btn theme-toggle" type="button" title="Cambiar tema">🌙</button>
   {% if DEV_MODE %}
   <div class="dev-banner">DEV MODE — security disabled</div>
   <style>
@@ -98,5 +99,27 @@
   <footer class="footer">
     <small>© 2025 SGC — Control de Calidad y Seguridad en Obra de Dragado</small>
   </footer>
+  <script>
+    (function(){
+      const root = document.documentElement;
+      const btn = document.getElementById('theme-toggle');
+
+      function apply(theme){
+        root.dataset.theme = theme;
+        btn.textContent = theme === 'dark' ? '☀️' : '🌙';
+        try { localStorage.setItem('theme', theme); } catch (e) {}
+      }
+
+      let saved = null;
+      try { saved = localStorage.getItem('theme'); } catch (e) {}
+      const prefersLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+      apply(saved || (prefersLight ? 'light' : 'dark'));
+
+      btn.addEventListener('click', function(){
+        const next = root.dataset.theme === 'light' ? 'dark' : 'light';
+        apply(next);
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/tests/test_theme_toggle.py
+++ b/tests/test_theme_toggle.py
@@ -1,0 +1,15 @@
+def test_theme_toggle_button_on_home(client):
+    rv = client.get("/")
+    assert rv.status_code == 200
+    html = rv.data.decode("utf-8")
+    assert 'id="theme-toggle"' in html
+    assert 'data-theme' in html
+
+
+def test_theme_css_has_both_themes(app):
+    with app.test_client() as c:
+        css = c.get("/static/css/app.css")
+    assert css.status_code == 200
+    text = css.data.decode("utf-8")
+    assert ":root" in text
+    assert "[data-theme='light']" in text


### PR DESCRIPTION
## Summary
- add theme-aware CSS variables with light and dark palettes and refresh base button styles
- inject a floating theme toggle button and persistence script in the base layout
- add tests ensuring the toggle markup renders and the CSS exposes both theme rules

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db71acecfc8326ba51f855a00f8e6c