### PR TITLE
ui(theme): move toggle to header

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -37,7 +37,7 @@ body{
 a{text-decoration:none;}
 .sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;}
 
-.navbar{
+header.nav{
   position:sticky;
   top:0;
   z-index:10;
@@ -50,10 +50,11 @@ a{text-decoration:none;}
   backdrop-filter:blur(6px);
 }
 
-.nav-left .brand{display:inline-flex; align-items:center; gap:10px; font-weight:600; letter-spacing:.3px;}
-.nav-left .brand .logo{height:24px; width:auto; display:block; border-radius:4px; box-shadow:0 0 0 1px rgba(255,255,255,.06);}
-
-.nav-right{display:flex; gap:10px; align-items:center;}
+header.nav .nav-left{display:flex; align-items:center; gap:20px;}
+header.nav .brand{display:inline-flex; align-items:center; gap:10px; font-weight:600; letter-spacing:.3px;}
+header.nav .brand .logo{height:24px; width:auto; display:block; border-radius:4px; box-shadow:0 0 0 1px rgba(255,255,255,.06);}
+header.nav .nav-links{display:flex; gap:12px; align-items:center; flex-wrap:wrap;}
+header.nav .nav-actions{display:flex; align-items:center; gap:8px;}
 
 .btn,
 button,
@@ -144,8 +145,9 @@ img,svg,canvas,video{max-width:100%; height:auto;}
 .hero-img{max-height:220px; width:100%; object-fit:contain; display:block; margin:10px auto;}
 
 /* ===== Theme toggle ===== */
-.theme-toggle{position:fixed; right:16px; bottom:16px; z-index:1000; opacity:.9;}
-.theme-toggle:hover{opacity:1;}
+.theme-toggle{position:static; right:auto; bottom:auto; z-index:auto; opacity:1;}
+.nav-theme{background:transparent; border:1px solid var(--border); padding:6px 10px; border-radius:10px;}
+.nav-theme:hover{filter:brightness(1.06);}
 
 /* Additional UI elements */
 .hero h1{font-size:28px; margin-bottom:4px;}
@@ -190,5 +192,5 @@ img,svg,canvas,video{max-width:100%; height:auto;}
 .table th,.table td{padding:8px 10px; border-bottom:1px solid var(--border);}
 .table th{text-align:left; color:var(--muted); font-weight:600;}
 
-header .nav a{padding:6px 8px; border-radius:8px;}
-header .nav a.active{background:#111827;}
+header.nav a{padding:6px 8px; border-radius:8px;}
+header.nav a.active{background:#111827;}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,6 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
 </head>
 <body>
-  <button id="theme-toggle" class="btn theme-toggle" type="button" title="Cambiar tema">🌙</button>
   {% if DEV_MODE %}
   <div class="dev-banner">DEV MODE — security disabled</div>
   <style>
@@ -27,38 +26,44 @@
     body { padding-top: 44px; }
   </style>
   {% endif %}
-  <header class="navbar">
+  <header class="nav">
     <div class="nav-left">
       <span class="brand">
         <img class="logo" src="{{ url_for('static', filename='img/siglo21.png') }}" alt="Siglo 21">
         <span>SGC-Obra</span>
       </span>
+      <nav class="nav-links">
+        {% if current_user.is_authenticated %}
+          {% if DEV_MODE %}
+          <a href="{{ url_for('dashboard_bp.index') }}">Dashboard</a>
+          {% endif %}
+          <a href="{{ url_for('equipos_bp.index') }}">Equipos</a>
+          <a href="{{ url_for('partes.index') }}">Partes</a>
+          <a href="{{ url_for('checklists_bp.templates_index') }}">Checklists</a>
+          {% if DEV_MODE %}
+          <a href="{{ url_for('checklists_bp.ejecutar') }}">Ejecutar</a>
+          <a href="{{ url_for('checklists_bp.runs_index') }}">Ejecuciones</a>
+          <a href="{{ url_for('partes.resumen') }}">Resumen Partes</a>
+          {% endif %}
+          <a href="{{ url_for('operadores_bp.index') }}">Operadores</a>
+        {% else %}
+          <a href="{{ url_for('public.home') }}">Inicio</a>
+        {% endif %}
+      </nav>
     </div>
-    <nav class="nav-right">
+    <div class="nav-actions">
+      <button id="theme-toggle" class="btn nav-theme" type="button" title="Cambiar tema">🌙</button>
       {% if current_user.is_authenticated %}
-        {% if DEV_MODE %}
-        <a href="{{ url_for('dashboard_bp.index') }}">Dashboard</a>
-        {% endif %}
-        <a href="{{ url_for('equipos_bp.index') }}">Equipos</a>
-        <a href="{{ url_for('partes.index') }}">Partes</a>
-        <a href="{{ url_for('checklists_bp.templates_index') }}">Checklists</a>
-        {% if DEV_MODE %}
-        <a href="{{ url_for('checklists_bp.ejecutar') }}">Ejecutar</a>
-        <a href="{{ url_for('checklists_bp.runs_index') }}">Ejecuciones</a>
-        <a href="{{ url_for('partes.resumen') }}">Resumen Partes</a>
-        {% endif %}
-        <a href="{{ url_for('operadores_bp.index') }}">Operadores</a>
-        <form method="post" action="{{ url_for('auth.logout') }}" class="inline">
-          {{ forms.csrf_field() }}
-          <button class="btn" type="submit">Logout</button>
-        </form>
+      <form method="post" action="{{ url_for('auth.logout') }}" class="inline">
+        {{ forms.csrf_field() }}
+        <button class="btn" type="submit">Logout</button>
+      </form>
       {% else %}
-        <a href="{{ url_for('public.home') }}">Inicio</a>
         {% if not DEV_MODE %}
         <a href="{{ url_for('auth.login') }}" class="btn">Login</a>
         {% endif %}
       {% endif %}
-    </nav>
+    </div>
   </header>
 
   <main class="container">

--- a/tests/test_theme_toggle.py
+++ b/tests/test_theme_toggle.py
@@ -13,3 +13,10 @@ def test_theme_css_has_both_themes(app):
     text = css.data.decode("utf-8")
     assert ":root" in text
     assert "[data-theme='light']" in text
+
+
+def test_theme_toggle_is_not_floating(app):
+    with app.test_client() as c:
+        css = c.get("/static/css/app.css")
+    txt = css.data.decode("utf-8")
+    assert "position:fixed" not in txt


### PR DESCRIPTION
## Summary
- move the theme toggle into the header actions so it sits next to the authentication controls
- update the header styling to remove floating button behavior and style the inline toggle
- add a regression test ensuring the toggle is no longer fixed-positioned

## Testing
- pytest tests/test_theme_toggle.py

------
https://chatgpt.com/codex/tasks/task_e_68dbb0da5d408326acd7c941c49c4d18