### PR TITLE
Add Evidencias buttons to Partes and Checklist Runs lists

### DIFF
--- a/app/templates/checklists/run_view.html
+++ b/app/templates/checklists/run_view.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1>Checklist ejecutado</h1>
+<p><a class="btn" href="{{ url_for('archivos_bp.index', run_id=r.id)|replace('/?', '?') }}">Evidencias</a></p>
 <p>Fecha: <strong>{{ r.fecha }}</strong> | Plantilla: <strong>{{ r.template.nombre }}</strong> ({{ r.template.norma or '-' }}) | %OK: <strong>{{ '%.1f'|format(r.pct_ok) }}%</strong></p>
 {% if r.notas %}<p>Notas: {{ r.notas }}</p>{% endif %}
 <table class="table">

--- a/app/templates/checklists/runs_index.html
+++ b/app/templates/checklists/runs_index.html
@@ -8,7 +8,7 @@
   <a href="{{ url_for('checklists_bp.resumen', desde=desde, hasta=hasta) }}">Resumen</a>
 </form>
 <table class="table">
-  <thead><tr><th>Fecha</th><th>Plantilla</th><th>Norma</th><th>% OK</th><th></th></tr></thead>
+  <thead><tr><th>Fecha</th><th>Plantilla</th><th>Norma</th><th>% OK</th><th>Acciones</th></tr></thead>
   <tbody>
     {% for r in rows %}
       <tr>
@@ -16,7 +16,8 @@
         <td>{{ r.template.nombre }}</td>
         <td>{{ r.template.norma }}</td>
         <td>{{ '%.1f'|format(r.pct_ok) }}%</td>
-        <td>
+        <td style="text-align:right; white-space:nowrap;">
+          <a class="btn" href="{{ url_for('archivos_bp.index', run_id=r.id)|replace('/?', '?') }}">Evidencias</a>
           <a href="{{ url_for('checklists_bp.run_view', id=r.id) }}">Ver</a>
           <a href="{{ url_for('checklists_bp.run_pdf', id=r.id) }}" target="_blank">PDF</a>
         </td>

--- a/app/templates/partes/index.html
+++ b/app/templates/partes/index.html
@@ -33,7 +33,7 @@
       <th>Horas</th>
       <th>Actividad</th>
       <th>Incidencias</th>
-      {% if DEV_MODE %}<th>Acciones</th>{% endif %}
+      <th>Acciones</th>
     </tr>
   </thead>
   <tbody>
@@ -45,15 +45,16 @@
       <td>{{ '%.2f'|format(r.horas_trabajo or 0) }}</td>
       <td>{{ r.actividad }}</td>
       <td>{{ r.incidencias }}</td>
-      {% if DEV_MODE %}
-      <td>
+      <td style="text-align:right; white-space:nowrap;">
+        <a class="btn" href="{{ url_for('archivos_bp.index', parte_id=r.id)|replace('/?', '?') }}">Evidencias</a>
+        {% if DEV_MODE %}
         <a href="{{ url_for('partes.pdf_parte', id=r.id) }}" target="_blank">PDF</a>
         <a href="{{ url_for('partes.edit', id=r.id) }}">Editar</a>
         <form method="post" action="{{ url_for('partes.delete', id=r.id) }}" style="display:inline" onsubmit="return confirm('¿Eliminar parte?');">
           <button type="submit">Eliminar</button>
         </form>
+        {% endif %}
       </td>
-      {% endif %}
     </tr>
     {% endfor %}
   </tbody>

--- a/tests/test_evidencias_buttons.py
+++ b/tests/test_evidencias_buttons.py
@@ -1,0 +1,72 @@
+from datetime import date
+
+import pytest
+
+
+def _ensure_parte(app):
+    from app.extensions import db
+    from app.models.parte_diaria import ParteDiaria
+
+    with app.app_context():
+        if db.session.query(ParteDiaria).count():
+            return db.session.query(ParteDiaria).first()
+        parte = ParteDiaria(fecha=date.today())
+        db.session.add(parte)
+        db.session.commit()
+        return parte
+
+
+def _ensure_run(app):
+    from app.extensions import db
+    from app.models.checklist import ChecklistRun, ChecklistTemplate
+
+    with app.app_context():
+        template = db.session.query(ChecklistTemplate).first()
+        if not template:
+            template = ChecklistTemplate(nombre="Demo", norma="")
+            db.session.add(template)
+            db.session.commit()
+        run = db.session.query(ChecklistRun).first()
+        if run:
+            return run
+        run = ChecklistRun(fecha=date.today(), template_id=template.id, pct_ok=100)
+        db.session.add(run)
+        db.session.commit()
+        return run
+
+
+def _first_ok(client, paths):
+    for p in paths:
+        r = client.get(p)
+        if r.status_code == 200:
+            return p, r
+    return None, None
+
+
+def test_partes_list_has_evidencias_button(client, app, monkeypatch):
+    monkeypatch.setenv("DISABLE_SECURITY", "1")
+    _ensure_parte(app)
+    path, resp = _first_ok(client, ["/partes/", "/partes"])
+    if not resp:
+        pytest.skip("No existe lista de Partes en rutas conocidas")
+    html = resp.data.decode("utf-8")
+    assert (
+        'href="/archivos?parte_id=' in html
+        or 'href="/archivos/?parte_id=' in html
+        or ('href="' in html and 'archivos?parte_id=' in html)
+    )
+
+
+def test_checklist_runs_list_has_evidencias_button(client, app, monkeypatch):
+    monkeypatch.setenv("DISABLE_SECURITY", "1")
+    _ensure_run(app)
+    candidates = ["/checklists/runs", "/checklists/runs/", "/checklists"]
+    path, resp = _first_ok(client, candidates)
+    if not resp:
+        pytest.skip("No existe lista de ChecklistRuns en rutas conocidas")
+    html = resp.data.decode("utf-8")
+    assert (
+        'href="/archivos?run_id=' in html
+        or 'href="/archivos/?run_id=' in html
+        or ('href="' in html and 'archivos?run_id=' in html)
+    )


### PR DESCRIPTION
## Summary
- add Evidencias action buttons to the Partes list and Checklist Run list views
- expose an Evidencias shortcut in the checklist run detail view
- add regression tests that ensure the Evidencias buttons are rendered on both listings

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddd7627e648326a080d3b46f9e9dd4