### PR TITLE
Highlight evidencias badge when attachments exist

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -124,6 +124,15 @@ textarea{min-height:var(--btn-h); height:auto;}
   font-size:12px; line-height:1; text-align:center;
   border-radius:999px; border:1px solid var(--border); background:var(--panel); color:var(--text);
 }
+/* Resalta el total cuando hay evidencias */
+.badge--alert{
+  border-color:#ef4444;
+  background:rgba(239,68,68,.15);
+}
+/* Ajuste sutil en tema claro */
+[data-theme='light'] .badge--alert{
+  background:rgba(239,68,68,.10);
+}
 .badge--pdf{ border-color:#ef4444 }
 .badge--img{ border-color:#3b82f6 }
 .badge-wrap{ display:inline-flex; align-items:center; gap:4px; margin-left:6px }

--- a/app/templates/checklists/runs_index.html
+++ b/app/templates/checklists/runs_index.html
@@ -20,7 +20,8 @@
           {% set s = evidencias_summary(run_id=r.id) %}
           <a class="btn" href="{{ url_for('archivos_bp.index', run_id=r.id)|replace('/?', '?') }}"
              title="Tamaño total: {{ s.size_h }}">
-            Evidencias <span class="badge">{{ s.total }}</span>
+            Evidencias
+            <span class="badge {{ 'badge--alert' if s.total > 0 else '' }}">{{ s.total }}</span>
             <span class="badge-wrap">
               <span class="badge badge--pdf">PDF {{ s.by_ext.pdf }}</span>
               <span class="badge badge--img">IMG {{ s.by_ext.img }}</span>

--- a/app/templates/partes/index.html
+++ b/app/templates/partes/index.html
@@ -49,7 +49,8 @@
         {% set s = evidencias_summary(parte_id=r.id) %}
         <a class="btn" href="{{ url_for('archivos_bp.index', parte_id=r.id)|replace('/?', '?') }}"
            title="Tamaño total: {{ s.size_h }}">
-          Evidencias <span class="badge">{{ s.total }}</span>
+          Evidencias
+          <span class="badge {{ 'badge--alert' if s.total > 0 else '' }}">{{ s.total }}</span>
           <span class="badge-wrap">
             <span class="badge badge--pdf">PDF {{ s.by_ext.pdf }}</span>
             <span class="badge badge--img">IMG {{ s.by_ext.img }}</span>

--- a/tests/test_evidencias_badge_alert.py
+++ b/tests/test_evidencias_badge_alert.py
@@ -1,0 +1,46 @@
+import io
+import re
+
+import pytest
+
+
+def _get_first_part_id(html: str):
+    """Busca la primera coincidencia de parte_id en los links de evidencias."""
+    match = re.search(r"archivos\\?parte_id=(\\d+)", html)
+    return int(match.group(1)) if match else None
+
+
+def test_css_has_badge_alert(app):
+    with app.test_client() as client:
+        response = client.get("/static/css/app.css")
+        assert response.status_code == 200
+        css = response.data.decode("utf-8")
+        assert ".badge--alert" in css
+
+
+def test_badge_alert_turns_on_when_uploading(client):
+    response = client.get("/partes")
+    if response.status_code != 200:
+        response = client.get("/partes/")
+    if response.status_code != 200:
+        pytest.skip("No existe lista de Partes en rutas conocidas")
+
+    html = response.data.decode("utf-8")
+    parte_id = _get_first_part_id(html)
+    if not parte_id:
+        pytest.skip("No se pudo inferir un parte_id desde la lista (href archivos?parte_id=...)")
+
+    data = {"file": (io.BytesIO(b"demo"), "x.pdf"), "parte_id": str(parte_id)}
+    upload = client.post(
+        "/archivos/upload",
+        data=data,
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+    assert upload.status_code == 200
+
+    response_after = client.get("/partes")
+    if response_after.status_code != 200:
+        response_after = client.get("/partes/")
+    html_after = response_after.data.decode("utf-8")
+    assert "badge--alert" in html_after


### PR DESCRIPTION
## Summary
- add a red-tinted badge style to highlight evidencias totals when items exist
- apply the conditional alert class on evidencias buttons in partes and checklist runs lists
- cover the new behavior with tests that validate CSS and a file upload scenario

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0262ab8808326b94ce8bfb6c1b570