### PR TITLE
ui(auth): show DEV banner on login with direct Dashboard link when LOGIN_DISABLED=1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -151,6 +151,10 @@ def create_app(config_name: str | None = None) -> Flask:
             pass
     # ===== FIN DEV MODE =====
 
+    app.jinja_env.globals["DEV_MODE"] = bool(
+        app.config.get("SECURITY_DISABLED") or app.config.get("LOGIN_DISABLED")
+    )
+
     # Inicializa extensiones aquí (después de setear flags):
     try:
         from app.extensions import login_manager

--- a/app/blueprints/auth/templates/auth/login.html
+++ b/app/blueprints/auth/templates/auth/login.html
@@ -4,6 +4,12 @@
 <section class="auth-wrap">
   <h1>Iniciar sesión</h1>
   <p class="text-muted">Ingresa tus credenciales. Las cuentas pendientes o rechazadas no pueden acceder.</p>
+  {% if DEV_MODE %}
+  <div class="alert alert--dev">
+    <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
+    <a class="btn" href="{{ url_for('dashboard_bp.index') }}">Ir al Dashboard</a>
+  </div>
+  {% endif %}
   <form method="post" action="{{ url_for('auth.login_post') }}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <label class="form-label">

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -137,6 +137,16 @@ textarea{min-height:var(--btn-h); height:auto;}
 .badge--img{ border-color:#3b82f6 }
 .badge-wrap{ display:inline-flex; align-items:center; gap:4px; margin-left:6px }
 
+.alert{
+  display:flex; align-items:center; gap:8px;
+  padding:8px 10px; border-radius:12px; margin:8px 0 12px;
+  border:1px solid var(--border); background:var(--panel); color:var(--text);
+}
+.alert b{font-weight:700}
+.alert--dev{ border-color:#f59e0b; background:rgba(245,158,11,.12); }
+[data-theme='light'] .alert--dev{ background:rgba(245,158,11,.10); }
+.alert .btn{margin-left:auto}
+
 .icon{display:block;}
 
 :focus-visible{outline:2px solid rgba(36,160,255,0.9); outline-offset:2px;}

--- a/tests/test_login_dev_banner.py
+++ b/tests/test_login_dev_banner.py
@@ -1,0 +1,15 @@
+def test_login_shows_dev_banner_when_login_disabled(app, client):
+    app.config["LOGIN_DISABLED"] = True
+    response = client.get("/auth/login")
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+    assert "Modo DEV" in html
+    assert 'href="/dashboard' in html
+
+
+def test_login_hides_dev_banner_when_enabled(app, client):
+    app.config["LOGIN_DISABLED"] = False
+    response = client.get("/auth/login")
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+    assert "Modo DEV" not in html


### PR DESCRIPTION
## Summary
- expose the DEV_MODE flag as a Jinja global after loading authentication toggles
- style a compact alert component and show the DEV banner with a Dashboard shortcut on the login view when auth is disabled
- add tests that cover the banner visibility and dashboard link based on LOGIN_DISABLED

## Testing
- pytest tests/test_login_dev_banner.py

------
https://chatgpt.com/codex/tasks/task_e_68e038356a388326aef46c8ce1bf62d3