### PR TITLE
ui(auth): show DEV banner on login with dashboard shortcut

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -151,10 +151,6 @@ def create_app(config_name: str | None = None) -> Flask:
             pass
     # ===== FIN DEV MODE =====
 
-    app.jinja_env.globals["DEV_MODE"] = bool(
-        app.config.get("SECURITY_DISABLED") or app.config.get("LOGIN_DISABLED")
-    )
-
     # Inicializa extensiones aquí (después de setear flags):
     try:
         from app.extensions import login_manager

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -137,6 +137,7 @@ textarea{min-height:var(--btn-h); height:auto;}
 .badge--img{ border-color:#3b82f6 }
 .badge-wrap{ display:inline-flex; align-items:center; gap:4px; margin-left:6px }
 
+/* Alertas compactas */
 .alert{
   display:flex; align-items:center; gap:8px;
   padding:8px 10px; border-radius:12px; margin:8px 0 12px;


### PR DESCRIPTION
## Summary
- ensure the DEV_MODE Jinja global only reflects the LOGIN_DISABLED flag
- document the compact alert styles used by the DEV login banner

## Testing
- pytest tests/test_login_dev_banner.py

------
https://chatgpt.com/codex/tasks/task_e_68e09546a6f08326a42c4fd83f8e54f4