### PR TITLE
auth(login): add GET /auth/login view and ensure blueprint registered

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -292,6 +292,11 @@ def create_app(config_name: str | None = None) -> Flask:
 
     blueprints = register_blueprints(app)
 
+    if "auth" not in app.blueprints:
+        from app.blueprints.auth.routes import bp as auth_bp
+
+        app.register_blueprint(auth_bp)
+
     # Registro de blueprints existentes
     try:
         from .routes.health import bp as health_bp

--- a/tests/test_auth_login.py
+++ b/tests/test_auth_login.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 
+def test_login_get_exists(client):
+    response = client.get("/auth/login")
+
+    assert response.status_code == 200
+
+
 def test_seed_admin_and_login_success(app, client):
     app.config.update(LOGIN_DISABLED=False, AUTH_SIMPLE=False)
 


### PR DESCRIPTION
## Summary
- expose the auth blueprint through the canonical `bp` alias so the login routes can be imported consistently
- guard blueprint registration in the app factory to ensure the auth views are available even if the registry skips them
- add a regression test that asserts `/auth/login` responds successfully

## Testing
- pytest tests/test_auth_login.py

------
https://chatgpt.com/codex/tasks/task_e_68e0b00c196483269c8a3aa63d08e03d