### PR TITLE
auth: add dev reset endpoint and tolerant login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ SECRET_KEY=change-me
 LOGIN_DISABLED=1
 WTF_CSRF_ENABLED=0
 
+# Dev reset endpoint (solo disponible con LOGIN_DISABLED=1)
+DEV_RESET_TOKEN=pon_algo_largo
+DEV_ADMIN_EMAIL=admin@admin.com
+DEV_ADMIN_PASS=admin123
+
 # DB
 DATABASE_URL=postgresql+psycopg://user:pass@host:5432/dbname
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ FLASK_APP=app:create_app flask users:seed-admin --email admin@admin.com --passwo
 
 Asegúrate de establecer `SECRET_KEY` y usar `LOGIN_DISABLED=0` en producción.
 
+## Reset rápido de admin en DEV
+
+1. En Render (o el entorno que uses) define estas variables:
+
+   ```text
+   LOGIN_DISABLED=1
+   WTF_CSRF_ENABLED=0
+   SECRET_KEY=<cadena_larga_unica>
+   DEV_RESET_TOKEN=<algo_largo>
+   DEV_ADMIN_EMAIL=admin@admin.com
+   DEV_ADMIN_PASS=admin123
+   ```
+
+2. Despliega nuevamente la app y abre en el navegador:
+
+   ```text
+   https://TU-APP.onrender.com/auth/dev-reset-admin?token=<DEV_RESET_TOKEN>
+   ```
+
+   Verás el mensaje `OK: admin reset — email=admin@admin.com pass=admin123`.
+
+3. Si quieres forzar login, cambia `LOGIN_DISABLED=0` y vuelve a desplegar. El acceso será:
+
+   - Usuario: `admin@admin.com`
+   - Contraseña: `admin123`
+
+Puedes mantener `LOGIN_DISABLED=1` durante el desarrollo para entrar directo a `/dashboard?days=30` sin autenticación.
+
 ## Operación
 
 - **Gunicorn:** El Procfile y `render.yaml` inician el proyecto con `gunicorn -w 3 -t 60 wsgi:app`.

--- a/app/blueprints/auth/utils.py
+++ b/app/blueprints/auth/utils.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any
+
+from flask import current_app
+from werkzeug.security import check_password_hash
+
+
+def normalize_email(value: str | None) -> str | None:
+    """Normalize email addresses for tolerant comparisons."""
+
+    if not isinstance(value, str):
+        return value
+    normalized = value.strip().casefold()
+    return normalized or None
+
+
+def _coerce_password_value(stored: str | bytes | None) -> str | None:
+    if stored is None:
+        return None
+    if isinstance(stored, bytes):
+        try:
+            return stored.decode("utf-8")
+        except Exception:
+            return None
+    if isinstance(stored, str):
+        return stored
+    return None
+
+
+def check_pwd_tolerant(stored: str | bytes | None, plain: str) -> bool:
+    """Validate *plain* against *stored* supporting multiple hash formats."""
+
+    if not plain:
+        return False
+
+    value = _coerce_password_value(stored)
+    if not value:
+        return False
+
+    try:
+        if value.startswith(("pbkdf2:", "scrypt:")) or ":" in value:
+            if check_password_hash(value, plain):
+                return True
+    except Exception:
+        # Fall through to other strategies.
+        pass
+
+    if value.startswith(("$2a$", "$2b$", "$2y$")):
+        try:
+            from flask_bcrypt import Bcrypt
+
+            bcrypt = Bcrypt(current_app)
+            return bool(bcrypt.check_password_hash(value, plain))
+        except Exception:
+            return False
+
+    try:
+        return bool(check_password_hash(value, plain))
+    except Exception:
+        return False
+
+
+def is_active_and_approved(user: Any) -> bool:
+    """Return ``True`` if the user appears active/approved across schemas."""
+
+    if hasattr(user, "is_active") and not getattr(user, "is_active"):
+        return False
+
+    for flag in ("approved", "is_approved", "aprobado"):
+        if hasattr(user, flag) and not getattr(user, flag):
+            return False
+
+    for field in ("status", "estado", "state"):
+        if hasattr(user, field):
+            raw = getattr(user, field)
+            value = (raw or "").strip().lower()
+            if value in {"rejected", "denied", "pendiente", "pending"}:
+                return False
+
+    return True

--- a/tests/test_auth_dev_reset_and_login.py
+++ b/tests/test_auth_dev_reset_and_login.py
@@ -1,0 +1,31 @@
+def test_dev_reset_admin_works_in_dev(app, client, monkeypatch):
+    app.config["LOGIN_DISABLED"] = True
+    monkeypatch.setenv("DEV_RESET_TOKEN", "tok")
+    response = client.get("/auth/dev-reset-admin?token=tok")
+    assert response.status_code == 200
+    assert "OK: admin reset" in response.data.decode()
+
+
+def test_dev_reset_admin_hidden_in_prod(app, client, monkeypatch):
+    app.config["LOGIN_DISABLED"] = False
+    monkeypatch.setenv("DEV_RESET_TOKEN", "tok")
+    response = client.get("/auth/dev-reset-admin?token=tok")
+    assert response.status_code in (403, 404)
+
+
+def test_login_after_reset(app, client, monkeypatch):
+    app.config["LOGIN_DISABLED"] = True
+    monkeypatch.setenv("DEV_RESET_TOKEN", "tok")
+    monkeypatch.setenv("DEV_ADMIN_EMAIL", "admin@admin.com")
+    monkeypatch.setenv("DEV_ADMIN_PASS", "admin123")
+    client.get("/auth/dev-reset-admin?token=tok")
+    app.config["LOGIN_DISABLED"] = False
+
+    assert client.get("/auth/login").status_code == 200
+
+    response = client.post(
+        "/auth/login",
+        data={"email": "admin@admin.com", "password": "admin123"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 303)


### PR DESCRIPTION
## Summary
- add reusable auth helpers to normalize emails, validate hashes, and check approval flags
- expose a `/auth/dev-reset-admin` endpoint gated behind `LOGIN_DISABLED` plus document the supporting env vars
- cover the dev reset flow with dedicated tests to ensure login stays functional

## Testing
- pytest tests/test_auth_dev_reset_and_login.py -q
- pytest tests/test_auth_login.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e11291db3083268cca2bf8ed7cbb39