### PR TITLE
Add SQLite defaults for tests and lazy CLI registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
   push:
 
+env:
+  FLASK_ENV: testing
+  SECRET_KEY: dummy
+  DATABASE_URL: sqlite:///test.db
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -12,5 +17,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install -r requirements.txt
-      - run: pytest -q --maxfail=1 --disable-warnings
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest -q --maxfail=1 --disable-warnings

--- a/app/commands.py
+++ b/app/commands.py
@@ -1,0 +1,13 @@
+"""Registro perezoso de comandos CLI."""
+
+from __future__ import annotations
+
+
+def register_commands(app):
+    """Registrar los comandos CLI principales evitando ciclos tempranos."""
+
+    from .cli import register_cli
+    from .cli_sync import register_sync_cli
+
+    register_cli(app)
+    register_sync_cli(app)

--- a/app/config.py
+++ b/app/config.py
@@ -97,6 +97,33 @@ class TestingConfig(Config):
         self.AUTH_SIMPLE = True
 
 
+class BaseConfig:
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+
+class TestConfig(BaseConfig):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///test.db")
+
+
+class DevConfig(BaseConfig):
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///dev.db")
+
+
+class ProdConfig(BaseConfig):
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL")
+
+
+def get_config():
+    env = os.getenv("FLASK_ENV", "development").lower()
+    if env in ("test", "testing"):
+        return TestConfig
+    if env.startswith("prod"):
+        return ProdConfig
+    return DevConfig
+
+
 def load_config(env: str | None = None) -> Config:
     env_name = (env or os.getenv("APP_ENV") or os.getenv("FLASK_ENV") or "production").lower()
 


### PR DESCRIPTION
## Summary
- add lightweight config classes with get_config() to prefer SQLite during development and tests
- update create_app() to seed base config, register CLI commands lazily, and keep the SQLAlchemy extension export stable
- introduce a commands helper module and set CI to use the testing environment with SQLite defaults

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68e1e637d2748326b4b29f95f3394dc5