### PR TITLE
Fix CI (SQLite), hashed auth CLI, and login blueprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,13 @@ on:
   pull_request:
   push:
 
-env:
-  FLASK_ENV: testing
-  SECRET_KEY: dummy
-  DATABASE_URL: sqlite:///test.db
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      FLASK_ENV: testing
+      SECRET_KEY: dummy
+      DATABASE_URL: sqlite:///test.db
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,0 +1,7 @@
+"""Alias de rutas de autenticación para evitar importaciones circulares."""
+
+from __future__ import annotations
+
+from app.blueprints.auth.routes import bp as auth_bp
+
+__all__ = ["auth_bp"]

--- a/app/auth/templates/auth/login.html
+++ b/app/auth/templates/auth/login.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Entrar{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Iniciar sesión</h1>
+  <p class="text-muted">Ingresa tus credenciales. Las cuentas pendientes o rechazadas no pueden acceder.</p>
+  {% if DEV_MODE %}
+  <div class="alert alert--dev">
+    <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
+    <a class="btn" href="{{ url_for('dashboard_bp.index') }}">Ir al Dashboard</a>
+  </div>
+  {% endif %}
+  <form method="post" action="{{ url_for('auth.login_post') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <label class="form-label">
+      Correo electrónico
+      <input class="form-control" type="email" name="email" required autofocus autocomplete="email">
+    </label>
+    <label class="form-label">
+      Contraseña
+      <input class="form-control" type="password" name="password" required>
+    </label>
+    <button type="submit">Entrar</button>
+    {% if config.get('ALLOW_SELF_SIGNUP') %}
+      <div class="mt-4 text-center">
+        <a href="{{ url_for('auth.register') }}" class="btn btn-lg btn-outline-primary">
+          ✨ Crear un nuevo usuario
+        </a>
+      </div>
+    {% endif %}
+  </form>
+</section>
+{% endblock %}

--- a/app/commands.py
+++ b/app/commands.py
@@ -2,6 +2,26 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
+import click
+
+from app.extensions import db
+from app.models import User
+
+
+def _assign_username(email: str) -> str:
+    base = (email.split("@", 1)[0] or email or "admin").strip() or "admin"
+    if not hasattr(User, "query") or not hasattr(User, "username"):
+        return base
+
+    candidate = base
+    suffix = 1
+    while User.query.filter_by(username=candidate).first():
+        candidate = f"{base}{suffix}"
+        suffix += 1
+    return candidate
+
 
 def register_commands(app):
     """Registrar los comandos CLI principales evitando ciclos tempranos."""
@@ -11,3 +31,78 @@ def register_commands(app):
 
     register_cli(app)
     register_sync_cli(app)
+
+    if "seed-admin" not in app.cli.commands:
+
+        @app.cli.command("seed-admin")
+        @click.option("--email", required=True)
+        @click.option("--password", required=True)
+        @click.option("--force", is_flag=True, default=False)
+        def seed_admin(email: str, password: str, force: bool) -> None:
+            """Crear o actualizar un usuario administrador con contraseña segura."""
+
+            email_clean = (email or "").strip().lower()
+            if not email_clean:
+                click.echo("Email requerido", err=True)
+                raise SystemExit(1)
+
+            user = User.query.filter_by(email=email_clean).first() if hasattr(User, "email") else None
+            if user and not force:
+                click.echo("Admin ya existe. Usa --force para regenerar la contraseña.")
+                return
+
+            if not user:
+                user = User()
+                if hasattr(user, "email"):
+                    setattr(user, "email", email_clean)
+                if hasattr(user, "username"):
+                    setattr(user, "username", _assign_username(email_clean))
+                db.session.add(user)
+
+            if hasattr(user, "set_password"):
+                user.set_password(password)
+            elif hasattr(user, "password_hash"):
+                from werkzeug.security import generate_password_hash
+
+                user.password_hash = generate_password_hash(password or "")
+
+            for attr, value in (
+                ("role", "admin"),
+                ("is_admin", True),
+                ("is_active", True),
+                ("status", "approved"),
+                ("is_approved", True),
+                ("force_change_password", False),
+            ):
+                if hasattr(user, attr):
+                    setattr(user, attr, value)
+
+            if hasattr(user, "approved_at"):
+                setattr(user, "approved_at", datetime.now(timezone.utc))
+
+            db.session.commit()
+            click.echo(f"Admin listo: {email_clean}")
+
+    @app.cli.command("set-password")
+    @click.option("--email", required=True)
+    @click.option("--password", required=True)
+    def set_password(email: str, password: str) -> None:
+        """Actualizar la contraseña de un usuario existente."""
+
+        email_clean = (email or "").strip().lower()
+        if not email_clean:
+            raise SystemExit("Usuario no encontrado")
+
+        user = User.query.filter_by(email=email_clean).first() if hasattr(User, "email") else None
+        if not user:
+            raise SystemExit("Usuario no encontrado")
+
+        if hasattr(user, "set_password"):
+            user.set_password(password)
+        elif hasattr(user, "password_hash"):
+            from werkzeug.security import generate_password_hash
+
+            user.password_hash = generate_password_hash(password or "")
+
+        db.session.commit()
+        click.echo("Contraseña actualizada.")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -154,7 +154,13 @@ class User(db.Model, UserMixin):
     )
 
     def set_password(self, password: str) -> None:
-        self.password_hash = generate_password_hash(password or "")
+        """Store the password using PBKDF2-SHA256 with a random salt."""
+
+        self.password_hash = generate_password_hash(
+            password or "",
+            method="pbkdf2:sha256",
+            salt_length=16,
+        )
 
     def check_password(self, password: str) -> bool:
         stored = self.password_hash or ""


### PR DESCRIPTION
## Summary
- scope the CI workflow to use the SQLite testing configuration variables for pytest runs
- update the user password helper to use PBKDF2 hashing and expose CLI helpers for seeding and resetting admin credentials
- add an auth blueprint alias and template so the login UI is available without circular imports

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68e1fe4adfc4832697bd2c42eca598ee