### PR TITLE
Add lockouts, MFA, and password reset security layer

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -312,6 +312,14 @@ def create_app(config_name: str | None = None) -> Flask:
 
         app.register_blueprint(auth_bp)
 
+    from app.auth.reset import reset_bp
+
+    app.register_blueprint(reset_bp)
+
+    from app.auth.totp import totp_bp
+
+    app.register_blueprint(totp_bp)
+
     # Registro de blueprints existentes
     try:
         from .routes.health import bp as health_bp
@@ -339,6 +347,10 @@ def create_app(config_name: str | None = None) -> Flask:
     from app.blueprints.dashboard.routes import bp as dashboard_bp
 
     app.register_blueprint(dashboard_bp)
+
+    from app.agent.routes import agent_bp
+
+    app.register_blueprint(agent_bp)
 
     try:
         from app.blueprints.archivos.routes import bp as archivos_bp

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,0 +1,3 @@
+"""Agent utilities blueprint package."""
+
+__all__ = ["env_audit"]

--- a/app/agent/env_audit.py
+++ b/app/agent/env_audit.py
@@ -1,0 +1,23 @@
+"""Simple environment configuration audit helpers."""
+
+from __future__ import annotations
+
+import os
+
+
+def env_audit() -> dict[str, object]:
+    """Return a quick assessment of critical environment variables."""
+
+    issues: list[str] = []
+    secret_key = os.getenv("SECRET_KEY", "")
+    if not secret_key or len(secret_key) < 24:
+        issues.append("SECRET_KEY débil o ausente")
+
+    database_url = os.getenv("DATABASE_URL", "")
+    if database_url and not database_url.startswith("postgresql"):
+        issues.append("DATABASE_URL no apunta a Postgres en producción")
+
+    return {"ok": not issues, "issues": issues}
+
+
+__all__ = ["env_audit"]

--- a/app/agent/routes.py
+++ b/app/agent/routes.py
@@ -1,0 +1,21 @@
+"""Routes for quick environment audits."""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+from flask_login import login_required
+
+from .env_audit import env_audit
+
+agent_bp = Blueprint("agent", __name__, url_prefix="/agent")
+
+
+@agent_bp.get("/env-audit")
+@login_required
+def env_a():
+    """Return the environment audit report as JSON."""
+
+    return jsonify(env_audit())
+
+
+__all__ = ["agent_bp"]

--- a/app/auth/reset.py
+++ b/app/auth/reset.py
@@ -1,0 +1,86 @@
+"""Blueprint implementing password reset via signed tokens."""
+
+from __future__ import annotations
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from app.db import db
+from app.models.user import User
+from app.security.policy import PASSWORD_MIN
+
+
+reset_bp = Blueprint(
+    "reset", __name__, url_prefix="/auth/reset", template_folder="templates"
+)
+
+
+def _serializer() -> URLSafeTimedSerializer:
+    secret_key = current_app.config["SECRET_KEY"]
+    return URLSafeTimedSerializer(secret_key, salt="pwd-reset")
+
+
+@reset_bp.route("/request", methods=["GET", "POST"])
+def reset_request():
+    """Request a password reset token."""
+
+    if request.method == "POST":
+        email = (request.form.get("email") or "").strip().lower()
+        user = User.query.filter_by(email=email).first()
+        if user:
+            token = _serializer().dumps({"uid": user.id})
+            current_app.logger.info(
+                "RESET URL: %s",
+                url_for("reset.reset_confirm", token=token, _external=True),
+            )
+        flash("Si el correo existe, se enviaron instrucciones de recuperación.", "info")
+        return redirect(url_for("auth.login"))
+
+    return render_template("auth/reset_request.html")
+
+
+@reset_bp.route("/confirm/<token>", methods=["GET", "POST"])
+def reset_confirm(token: str):
+    """Confirm the reset token and set a new password."""
+
+    try:
+        data = _serializer().loads(token, max_age=1800)
+    except SignatureExpired:
+        flash("Token expirado", "warning")
+        return redirect(url_for("reset.reset_request"))
+    except BadSignature:
+        flash("Token inválido", "danger")
+        return redirect(url_for("reset.reset_request"))
+
+    user = db.session.get(User, data.get("uid")) if data else None
+    if not user:
+        flash("Usuario no encontrado", "danger")
+        return redirect(url_for("reset.reset_request"))
+
+    if request.method == "POST":
+        password = request.form.get("password") or ""
+        if len(password) < PASSWORD_MIN:
+            flash(
+                f"La contraseña debe tener al menos {PASSWORD_MIN} caracteres.",
+                "warning",
+            )
+            return render_template(
+                "auth/reset_confirm.html", password_min=PASSWORD_MIN
+            )
+        user.set_password(password)
+        db.session.commit()
+        flash("Contraseña actualizada. Inicia sesión.", "success")
+        return redirect(url_for("auth.login"))
+
+    return render_template("auth/reset_confirm.html", password_min=PASSWORD_MIN)
+
+
+__all__ = ["reset_bp"]

--- a/app/auth/templates/auth/reset_confirm.html
+++ b/app/auth/templates/auth/reset_confirm.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Nueva contraseña{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Define una nueva contraseña</h1>
+  <p class="text-muted">La contraseña debe tener al menos {{ password_min }} caracteres.</p>
+  <form method="post" action="">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <label class="form-label">
+      Nueva contraseña
+      <input class="form-control" type="password" name="password" required autofocus autocomplete="new-password" minlength="{{ password_min }}">
+    </label>
+    <button type="submit">Actualizar contraseña</button>
+  </form>
+  <p class="mt-4"><a href="{{ url_for('auth.login') }}">Volver al inicio de sesión</a></p>
+</section>
+{% endblock %}

--- a/app/auth/templates/auth/reset_request.html
+++ b/app/auth/templates/auth/reset_request.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Recuperar contraseña{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Recuperar contraseña</h1>
+  <p class="text-muted">Ingresa tu correo y, si existe una cuenta, enviaremos un enlace temporal.</p>
+  <form method="post" action="{{ url_for('reset.reset_request') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <label class="form-label">
+      Correo electrónico
+      <input class="form-control" type="email" name="email" required autofocus autocomplete="email">
+    </label>
+    <button type="submit">Enviar instrucciones</button>
+  </form>
+  <p class="mt-4"><a href="{{ url_for('auth.login') }}">Volver a iniciar sesión</a></p>
+</section>
+{% endblock %}

--- a/app/auth/templates/auth/totp_setup.html
+++ b/app/auth/templates/auth/totp_setup.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Configurar MFA{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Autenticación de dos factores</h1>
+  {% if secret %}
+    <p class="text-muted">Ya tienes MFA configurado. Escanea el código nuevamente o utiliza la clave para configurar otro dispositivo.</p>
+    <div class="card">
+      <div class="card-body">
+        <p><strong>Clave:</strong> <code>{{ secret }}</code></p>
+        {% if uri %}
+          <p><strong>URI:</strong> <code>{{ uri }}</code></p>
+        {% endif %}
+      </div>
+    </div>
+    <form method="post" action="{{ url_for('totp.totp_setup') }}" class="mt-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit">Generar nueva clave</button>
+    </form>
+  {% else %}
+    <p class="text-muted">Habilita MFA para agregar una capa adicional de seguridad a tu cuenta.</p>
+    <form method="post" action="{{ url_for('totp.totp_setup') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit">Habilitar MFA</button>
+    </form>
+  {% endif %}
+  <p class="mt-4"><a href="{{ url_for('dashboard.index') }}">Regresar al dashboard</a></p>
+</section>
+{% endblock %}

--- a/app/auth/templates/auth/totp_verify.html
+++ b/app/auth/templates/auth/totp_verify.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Verificar código MFA{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Verificación en dos pasos</h1>
+  <p class="text-muted">Introduce el código de 6 dígitos generado por tu aplicación de autenticación.</p>
+  <form method="post" action="{{ url_for('totp.totp_verify') }}">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <label class="form-label">
+      Código
+      <input class="form-control" type="text" name="code" pattern="\d{6}" maxlength="6" required autofocus autocomplete="one-time-code">
+    </label>
+    <button type="submit">Verificar</button>
+  </form>
+  {% if uri %}
+    <div class="mt-4">
+      <p class="text-muted">Si necesitas configurar nuevamente, usa el siguiente enlace en tu app:</p>
+      <code>{{ uri }}</code>
+    </div>
+  {% endif %}
+  <p class="mt-4"><a href="{{ url_for('auth.login') }}">Volver al inicio de sesión</a></p>
+</section>
+{% endblock %}

--- a/app/auth/totp.py
+++ b/app/auth/totp.py
@@ -1,0 +1,93 @@
+"""Blueprint to manage Time-based One-Time Password (TOTP) flows."""
+
+from __future__ import annotations
+
+import pyotp
+from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask_login import current_user, login_required, login_user
+
+from app.db import db
+from app.models.user import User
+
+
+totp_bp = Blueprint("totp", __name__, url_prefix="/auth/totp", template_folder="templates")
+
+
+@totp_bp.route("/setup", methods=["GET", "POST"])
+@login_required
+def totp_setup():
+    """Allow the authenticated user to enrol in MFA."""
+
+    if request.method == "POST":
+        secret = pyotp.random_base32()
+        current_user.totp_secret = secret
+        db.session.commit()
+        flash(
+            "MFA habilitado. Configura tu app de autenticación con la clave mostrada.",
+            "success",
+        )
+        return redirect(url_for("totp.totp_setup"))
+
+    secret = getattr(current_user, "totp_secret", None)
+    uri = None
+    if secret:
+        uri = pyotp.TOTP(secret).provisioning_uri(
+            name=_user_identifier(current_user), issuer_name="SGC"
+        )
+
+    return render_template("auth/totp_setup.html", secret=secret, uri=uri)
+
+
+@totp_bp.route("/verify", methods=["GET", "POST"])
+def totp_verify():
+    """Verify the MFA code after password authentication."""
+
+    uid = session.get("2fa_uid")
+    if not uid:
+        return redirect(url_for("auth.login"))
+
+    user = db.session.get(User, uid)
+    if not user or not getattr(user, "totp_secret", None):
+        session.pop("2fa_uid", None)
+        session.pop("2fa_next", None)
+        session.pop("2fa_remember", None)
+        return redirect(url_for("auth.login"))
+
+    provisioning_uri = pyotp.TOTP(user.totp_secret).provisioning_uri(
+        name=_user_identifier(user),
+        issuer_name="SGC",
+    )
+
+    if request.method == "POST":
+        code = (request.form.get("code") or "").strip()
+        totp = pyotp.TOTP(user.totp_secret)
+        if totp.verify(code, valid_window=1):
+            remember_flag = session.pop("2fa_remember", None)
+            remember = True if remember_flag is None else bool(remember_flag)
+            next_url = session.pop("2fa_next", None)
+            session.pop("2fa_uid", None)
+            login_user(user, remember=remember)
+            from app.blueprints.auth.routes import _redirect_for_role  # lazy import
+
+            role = _resolve_role_for_user(user)
+            if getattr(user, "force_change_password", False):
+                flash("Debes actualizar tu contraseña antes de continuar.", "info")
+                return redirect(url_for("auth.change_password"))
+            flash("Autenticación verificada", "success")
+            return _redirect_for_role(role, next_url)
+        flash("Código inválido", "danger")
+
+    return render_template("auth/totp_verify.html", uri=provisioning_uri)
+
+
+def _resolve_role_for_user(user: User) -> str:
+    from app.blueprints.auth.routes import _resolve_role
+
+    return _resolve_role(user)
+
+
+def _user_identifier(user: User) -> str:
+    return user.email or getattr(user, "username", f"user-{user.id}") or f"user-{user.id}"
+
+
+__all__ = ["totp_bp"]

--- a/app/security/__init__.py
+++ b/app/security/__init__.py
@@ -10,6 +10,7 @@ from flask_login import current_user
 
 from .jwt import encode_jwt, decode_jwt  # noqa: F401
 from .guards import requires_auth, requires_role  # noqa: F401
+from .policy import is_locked, register_fail, reset_fail_counter  # noqa: F401
 
 __all__ = [
     "encode_jwt",
@@ -19,6 +20,9 @@ __all__ = [
     "require_login",
     "generate_reset_token",
     "parse_reset_token",
+    "is_locked",
+    "register_fail",
+    "reset_fail_counter",
 ]
 
 

--- a/app/security/policy.py
+++ b/app/security/policy.py
@@ -1,0 +1,50 @@
+"""Security policy helpers for lockouts and password hygiene."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from app.db import db
+
+PASSWORD_MIN = 12
+LOCK_MAX_ATTEMPTS = 5
+LOCK_COOLDOWN_MIN = 15
+SESSION_IDLE_MIN = 20
+
+
+def is_locked(user, now: datetime | None = None) -> bool:
+    """Return True if the user is currently locked out."""
+
+    now = now or datetime.utcnow()
+    lock_until = getattr(user, "lock_until", None)
+    return bool(lock_until and lock_until > now)
+
+
+def register_fail(user, now: datetime | None = None) -> None:
+    """Increment failed login counter and lock the account if needed."""
+
+    now = now or datetime.utcnow()
+    failed = getattr(user, "failed_logins", 0) or 0
+    user.failed_logins = failed + 1
+    if user.failed_logins >= LOCK_MAX_ATTEMPTS:
+        user.lock_until = now + timedelta(minutes=LOCK_COOLDOWN_MIN)
+    db.session.commit()
+
+
+def reset_fail_counter(user) -> None:
+    """Reset failed login counters after a successful authentication."""
+
+    user.failed_logins = 0
+    user.lock_until = None
+    db.session.commit()
+
+
+__all__ = [
+    "PASSWORD_MIN",
+    "LOCK_MAX_ATTEMPTS",
+    "LOCK_COOLDOWN_MIN",
+    "SESSION_IDLE_MIN",
+    "is_locked",
+    "register_fail",
+    "reset_fail_counter",
+]

--- a/migrations/versions/20251015_security_layer.py
+++ b/migrations/versions/20251015_security_layer.py
@@ -1,0 +1,24 @@
+"""Add lockout counters and TOTP secret to users."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251015_security_layer"
+down_revision = "20251014_alembic_version_64"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("failed_logins", sa.Integer(), server_default="0"))
+    op.add_column("users", sa.Column("lock_until", sa.DateTime(), nullable=True))
+    op.add_column("users", sa.Column("totp_secret", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "totp_secret")
+    op.drop_column("users", "lock_until")
+    op.drop_column("users", "failed_logins")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,14 @@ Flask==3.0.3
 gunicorn==22.0.0
 
 # Utilidades para seguridad de Flask
-itsdangerous==2.2.0
+itsdangerous>=2.2
 Jinja2==3.1.4
 Werkzeug==3.0.3
 Flask-Login>=0.6.3
 Flask-Bcrypt>=1.0.1
 Flask-WTF>=1.2.1
-Flask-Limiter>=3.7.0
+Flask-Limiter>=3.7
+pyotp>=2.9
 PyJWT>=2.9.0
 email-validator>=2.2.0
 


### PR DESCRIPTION
## Summary
- add security policy helpers, new user fields, and alembic migration for login lockouts and MFA secrets
- implement TOTP setup/verification, token-based password reset flow, and register new blueprints
- expose environment audit endpoint and update requirements for new dependencies

## Testing
- pytest tests/test_auth_login.py::test_seed_admin_and_login_success

------
https://chatgpt.com/codex/tasks/task_e_68e24daf95b083268cbab924d66ce628