### PR TITLE
Add security policies with lockout, MFA, and env audit

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -347,6 +347,18 @@ def create_app(config_name: str | None = None) -> Flask:
     except Exception:
         pass
 
+    from app.auth.reset import reset_bp
+
+    app.register_blueprint(reset_bp)
+
+    from app.auth.totp import totp_bp
+
+    app.register_blueprint(totp_bp)
+
+    from app.agent.routes import agent_bp
+
+    app.register_blueprint(agent_bp)
+
     env_name = (app.config.get("ENV") or "production").lower()
     if env_name not in {"prod", "production"}:
         try:

--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities and routes for operational agents."""

--- a/app/agent/env_audit.py
+++ b/app/agent/env_audit.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+
+
+def env_audit() -> dict[str, object]:
+    issues: list[str] = []
+    secret_key = os.getenv("SECRET_KEY", "")
+    if not secret_key or len(secret_key) < 24:
+        issues.append("SECRET_KEY débil o ausente")
+    database_url = os.getenv("DATABASE_URL", "")
+    if database_url and not database_url.startswith("postgresql"):
+        issues.append("DATABASE_URL no apunta a Postgres en producción")
+    elif not database_url:
+        issues.append("DATABASE_URL no apunta a Postgres en producción")
+    return {"ok": not issues, "issues": issues}

--- a/app/agent/routes.py
+++ b/app/agent/routes.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify
+from flask_login import login_required
+
+from .env_audit import env_audit
+
+agent_bp = Blueprint("agent", __name__, url_prefix="/agent")
+
+
+@agent_bp.route("/env-audit")
+@login_required
+def env_a():
+    return jsonify(env_audit())

--- a/app/auth/templates/auth/reset_confirm.html
+++ b/app/auth/templates/auth/reset_confirm.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Restablecer contraseña{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Restablecer contraseña</h1>
+  <p class="text-muted">Define una nueva contraseña segura para continuar.</p>
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <label class="form-label">
+      Nueva contraseña
+      <input class="form-control" type="password" name="password" required minlength="12" autocomplete="new-password">
+    </label>
+    <button type="submit">Guardar contraseña</button>
+    <p class="mt-4"><a href="{{ url_for('auth.login') }}">← Ir al inicio de sesión</a></p>
+  </form>
+</section>
+{% endblock %}

--- a/app/auth/templates/auth/reset_request.html
+++ b/app/auth/templates/auth/reset_request.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Recuperar contraseña{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Recuperar contraseña</h1>
+  <p class="text-muted">Ingresa el correo asociado a tu cuenta y te enviaremos un enlace para restablecerla.</p>
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <label class="form-label">
+      Correo electrónico
+      <input class="form-control" type="email" name="email" required autofocus autocomplete="email">
+    </label>
+    <button type="submit">Enviar enlace</button>
+    <p class="mt-4"><a href="{{ url_for('auth.login') }}">← Volver al inicio de sesión</a></p>
+  </form>
+</section>
+{% endblock %}

--- a/app/auth/templates/auth/totp_setup.html
+++ b/app/auth/templates/auth/totp_setup.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Configurar MFA{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Autenticación de dos factores</h1>
+  <p class="text-muted">Protege tu cuenta con un código temporal (TOTP) generado desde una app como Google Authenticator o 1Password.</p>
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <button type="submit">Habilitar MFA</button>
+  </form>
+  {% if secret %}
+    <div class="mt-4">
+      <h2>Configuración actual</h2>
+      <p>Escanea este URI en tu app TOTP o copia el código manualmente:</p>
+      <pre class="bg-light p-3" style="white-space: pre-wrap; word-break: break-all;">{{ uri }}</pre>
+      <p><strong>Clave secreta:</strong> {{ secret }}</p>
+    </div>
+  {% endif %}
+  <p class="mt-4"><a href="{{ url_for('dashboard.index') }}">← Volver al panel</a></p>
+</section>
+{% endblock %}

--- a/app/auth/templates/auth/totp_verify.html
+++ b/app/auth/templates/auth/totp_verify.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Verificar código MFA{% endblock %}
+{% block content %}
+<section class="auth-wrap">
+  <h1>Verificar código</h1>
+  <p class="text-muted">Introduce el código de 6 dígitos generado por tu aplicación de autenticación.</p>
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <label class="form-label">
+      Código TOTP
+      <input class="form-control" type="text" name="code" required autofocus inputmode="numeric" pattern="\d{6}" autocomplete="one-time-code">
+    </label>
+    <button type="submit">Verificar</button>
+  </form>
+  {% if uri %}
+    <div class="mt-4">
+      <p>Si necesitas volver a configurar tu app, usa este URI:</p>
+      <pre class="bg-light p-3" style="white-space: pre-wrap; word-break: break-all;">{{ uri }}</pre>
+    </div>
+  {% endif %}
+  <p class="mt-4"><a href="{{ url_for('auth.login') }}">← Cambiar de cuenta</a></p>
+</section>
+{% endblock %}

--- a/app/auth/totp.py
+++ b/app/auth/totp.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pyotp
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from flask_login import current_user, login_required, login_user
+
+from app import db
+from app.models.user import User
+
+
+def _issuer_name() -> str:
+    return current_app.config.get("APP_NAME", "SGC")
+
+
+totp_bp = Blueprint(
+    "totp",
+    __name__,
+    url_prefix="/auth/totp",
+    template_folder="templates",
+)
+
+
+def _clear_totp_session() -> None:
+    for key in ("2fa_uid", "2fa_next", "2fa_remember", "2fa_force_change"):
+        session.pop(key, None)
+
+
+@totp_bp.route("/setup", methods=["GET", "POST"])
+@login_required
+def totp_setup():
+    secret = current_user.totp_secret
+    if request.method == "POST":
+        secret = pyotp.random_base32()
+        current_user.totp_secret = secret
+        db.session.commit()
+        flash("MFA habilitado", "success")
+        return redirect(url_for("totp.totp_setup"))
+
+    uri = None
+    if secret:
+        identifier = current_user.email or current_user.username or str(current_user.id)
+        uri = pyotp.TOTP(secret).provisioning_uri(name=identifier, issuer_name=_issuer_name())
+    return render_template("auth/totp_setup.html", secret=secret, uri=uri)
+
+
+@totp_bp.route("/verify", methods=["GET", "POST"])
+def totp_verify():
+    uid = session.get("2fa_uid")
+    if not uid:
+        return redirect(url_for("auth.login"))
+
+    user = db.session.get(User, uid)
+    if not user or not getattr(user, "totp_secret", None):
+        _clear_totp_session()
+        return redirect(url_for("auth.login"))
+
+    uri = pyotp.TOTP(user.totp_secret).provisioning_uri(
+        name=user.email or user.username or str(user.id),
+        issuer_name=_issuer_name(),
+    )
+
+    if request.method == "POST":
+        code = (request.form.get("code") or "").strip()
+        totp = pyotp.TOTP(user.totp_secret)
+        if totp.verify(code, valid_window=1):
+            remember = session.pop("2fa_remember", True)
+            next_url = session.pop("2fa_next", None)
+            force_change = session.pop("2fa_force_change", False)
+            session.pop("2fa_uid", None)
+            login_user(user, remember=remember)
+            flash("Bienvenido 👋", "success")
+            if force_change and getattr(user, "force_change_password", False):
+                flash("Debes actualizar tu contraseña antes de continuar.", "info")
+                return redirect(url_for("auth.change_password"))
+            if next_url:
+                return redirect(next_url)
+            from app.blueprints.auth.routes import _redirect_for_role, _resolve_role
+
+            role = _resolve_role(user)
+            return _redirect_for_role(role)
+        flash("Código inválido", "danger")
+    return render_template("auth/totp_verify.html", uri=uri)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from flask_login import UserMixin
-from sqlalchemy import Boolean, DateTime, Index, String, event
+from sqlalchemy import Boolean, DateTime, Index, Integer, String, event
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import expression
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -49,6 +49,14 @@ class User(db.Model, UserMixin):
     title: Mapped[str | None] = mapped_column(String(80), nullable=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     force_change_password: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    failed_logins: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
+    lock_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=False), nullable=True)
+    totp_secret: Mapped[str | None] = mapped_column(String(64), nullable=True)
     is_active: Mapped[bool] = mapped_column(
         Boolean,
         default=True,

--- a/app/security/policy.py
+++ b/app/security/policy.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+PASSWORD_MIN = 12
+LOCK_MAX_ATTEMPTS = 5
+LOCK_COOLDOWN_MIN = 15
+SESSION_IDLE_MIN = 20
+
+
+def is_locked(user, now: datetime | None = None) -> bool:
+    now = now or datetime.utcnow()
+    return bool(getattr(user, "lock_until", None) and user.lock_until > now)
+
+
+def register_fail(user, now: datetime | None = None) -> None:
+    from app import db
+
+    now = now or datetime.utcnow()
+    current = getattr(user, "failed_logins", 0) or 0
+    user.failed_logins = current + 1
+    if user.failed_logins >= LOCK_MAX_ATTEMPTS:
+        user.lock_until = now + timedelta(minutes=LOCK_COOLDOWN_MIN)
+    db.session.commit()
+
+
+def reset_fail_counter(user) -> None:
+    from app import db
+
+    user.failed_logins = 0
+    user.lock_until = None
+    db.session.commit()

--- a/migrations/versions/20251015_security_layer.py
+++ b/migrations/versions/20251015_security_layer.py
@@ -1,0 +1,27 @@
+"""Add security lockout and TOTP columns"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20251015_security_layer"
+down_revision = "20251014_alembic_version_64"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("failed_logins", sa.Integer(), server_default="0"),
+    )
+    op.add_column("users", sa.Column("lock_until", sa.DateTime(), nullable=True))
+    op.add_column("users", sa.Column("totp_secret", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "totp_secret")
+    op.drop_column("users", "lock_until")
+    op.drop_column("users", "failed_logins")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,14 +5,15 @@ Flask==3.0.3
 gunicorn==22.0.0
 
 # Utilidades para seguridad de Flask
-itsdangerous==2.2.0
+itsdangerous>=2.2
 Jinja2==3.1.4
 Werkzeug==3.0.3
 Flask-Login>=0.6.3
 Flask-Bcrypt>=1.0.1
 Flask-WTF>=1.2.1
-Flask-Limiter>=3.7.0
+Flask-Limiter>=3.7
 PyJWT>=2.9.0
+pyotp>=2.9
 email-validator>=2.2.0
 
 # Testing


### PR DESCRIPTION
## Summary
- add security policy helpers and extend the user model plus Alembic migration for lockouts and TOTP secrets
- implement password reset via signed token, MFA setup/verification flows, and new templates
- expose an environment audit endpoint and wire new blueprints/dependencies into the app

## Testing
- pytest tests/test_auth_login.py::test_login_fail_wrong_password -q

------
https://chatgpt.com/codex/tasks/task_e_68e2b56a6178832699cfc6a9bad0d368