### PR TITLE
Fix imports (authz), ensure packages, template config injection

### DIFF
--- a/app/auth/dev.py
+++ b/app/auth/dev.py
@@ -23,9 +23,9 @@ def dev_login():
 
     login_user(user, remember=True)
 
-    target = "dashboard_bp.index"
+    target = "dashboard.index"
     if target not in current_app.view_functions:
-        target = "dashboard.index"
+        target = "dashboard_bp.index"
     return redirect(url_for(target))
 
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -205,8 +205,10 @@ def login_post():
 
 @auth_bp.before_app_request
 def _enforce_force_change_password():
-    if current_app.config.get("SECURITY_DISABLED") or current_app.config.get(
-        "LOGIN_DISABLED"
+    if (
+        current_app.config.get("AUTH_DISABLED")
+        or current_app.config.get("SECURITY_DISABLED")
+        or current_app.config.get("LOGIN_DISABLED")
     ):
         return None
     allowed = {"auth.logout", "auth.change_password", "static"}
@@ -221,6 +223,11 @@ def _enforce_force_change_password():
 
 @auth_bp.get("/login")
 def login():
+    if current_app.config.get("AUTH_DISABLED", False):
+        target = "dashboard.index"
+        if target not in current_app.view_functions:
+            target = "dashboard_bp.index"
+        return redirect(url_for(target))
     if current_app.config.get("AUTH_SIMPLE", True) and session.get("user"):
         role = _resolve_role(session.get("user"))
         return redirect(url_for(_endpoint_for_role(role)))

--- a/app/auth/templates/auth/login.html
+++ b/app/auth/templates/auth/login.html
@@ -4,10 +4,15 @@
 <section class="auth-wrap">
   <h1>Iniciar sesión</h1>
   <p class="text-muted">Ingresa tus credenciales. Las cuentas pendientes o rechazadas no pueden acceder.</p>
-  {% if DEV_MODE %}
-  <div class="alert alert--dev">
+  {% if config.AUTH_DISABLED %}
+  <div class="dev-banner">
     <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
-    <a class="btn" href="{{ url_for('dashboard_bp.index') }}">Ir al Dashboard</a>
+    <a class="btn" href="{{ url_for('dashboard.index') }}">Ir al Dashboard</a>
+  </div>
+  {% elif DEV_MODE %}
+  <div class="dev-banner">
+    <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
+    <a class="btn" href="{{ url_for('dashboard.index') }}">Ir al Dashboard</a>
   </div>
   {% endif %}
   <form method="post" action="{{ url_for('auth.login_post') }}">

--- a/app/blueprints/auth/templates/auth/login.html
+++ b/app/blueprints/auth/templates/auth/login.html
@@ -4,10 +4,15 @@
 <section class="auth-wrap">
   <h1>Iniciar sesión</h1>
   <p class="text-muted">Ingresa tus credenciales. Las cuentas pendientes o rechazadas no pueden acceder.</p>
-  {% if DEV_MODE %}
-  <div class="alert alert--dev">
+  {% if config.AUTH_DISABLED %}
+  <div class="dev-banner">
     <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
-    <a class="btn" href="{{ url_for('dashboard_bp.index') }}">Ir al Dashboard</a>
+    <a class="btn" href="{{ url_for('dashboard.index') }}">Ir al Dashboard</a>
+  </div>
+  {% elif DEV_MODE %}
+  <div class="dev-banner">
+    <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
+    <a class="btn" href="{{ url_for('dashboard.index') }}">Ir al Dashboard</a>
   </div>
   {% endif %}
   <form method="post" action="{{ url_for('auth.login_post') }}">

--- a/app/blueprints/equipos/__init__.py
+++ b/app/blueprints/equipos/__init__.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from flask import Blueprint
 
-from app.security import require_login
+from app.security import register_login_guard
 
 bp = Blueprint("equipos_bp", __name__, url_prefix="/equipos")
 
-require_login(bp, exclude=("index",))
+register_login_guard(bp, exclude=("index",))
 
 from . import routes  # noqa: E402,F401

--- a/app/blueprints/operadores/__init__.py
+++ b/app/blueprints/operadores/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from flask import Blueprint
 
-from app.security import require_login
+from app.security import register_login_guard
 
 bp = Blueprint(
     "operadores_bp",
@@ -11,6 +11,6 @@ bp = Blueprint(
     template_folder="../../templates/operadores",
 )
 
-require_login(bp, exclude=("index",))
+register_login_guard(bp, exclude=("index",))
 
 from . import routes  # noqa: E402,F401

--- a/app/security/authz.py
+++ b/app/security/authz.py
@@ -1,0 +1,32 @@
+"""Reusable authorization decorators for the Codex app."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+from flask import current_app
+from flask_login import login_required as flask_login_required
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def require_login(view_func: F) -> F:
+    """Wrap a view with ``flask_login.login_required`` honoring AUTH_DISABLED."""
+
+    login_required_view = flask_login_required(view_func)
+
+    @wraps(view_func)
+    def wrapper(*args: Any, **kwargs: Any):
+        if (
+            current_app.config.get("AUTH_DISABLED")
+            or current_app.config.get("LOGIN_DISABLED")
+            or current_app.config.get("SECURITY_DISABLED")
+        ):
+            return view_func(*args, **kwargs)
+        return login_required_view(*args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
+__all__ = ["require_login"]

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -35,7 +35,7 @@
       <nav class="nav-links">
         {% if current_user.is_authenticated %}
           {% if DEV_MODE %}
-          <a href="{{ url_for('dashboard_bp.index') }}">Dashboard</a>
+          <a href="{{ url_for('dashboard.index') }}">Dashboard</a>
           {% endif %}
           <a href="{{ url_for('equipos_bp.index') }}">Equipos</a>
           <a href="{{ url_for('partes.index') }}">Partes</a>
@@ -69,7 +69,7 @@
   <main class="container">
     {% if current_user.is_authenticated %}
       <nav>
-        <a href="{{ url_for('dashboard_bp.index') }}">Dashboard</a> |
+        <a href="{{ url_for('dashboard.index') }}">Dashboard</a> |
         <a href="{{ url_for('equipos_bp.index') }}">Equipos</a> |
         <a href="{{ url_for('operadores_bp.index') }}">Operadores</a> |
         <a href="{{ url_for('checklists_bp.templates_index') }}">Checklists</a>

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -13,14 +13,14 @@
   <a class="card" href="{{ url_for('operadores_bp.index', vencidas=1) }}">Licencias vencidas <b>{{ counts.get('lic_vencidas') }}</b></a>
 </div>
 
-<form method="get" action="{{ url_for('dashboard_bp.index') }}" class="section">
+<form method="get" action="{{ url_for('dashboard.index') }}" class="section">
   <label class="muted">Rango:</label>
   <select name="days" onchange="this.form.submit()">
     {% for d in [7,14,30,60,90] %}
       <option value="{{ d }}" {% if days==d %}selected{% endif %}>{{ d }} días</option>
     {% endfor %}
   </select>
-  <a class="card" style="display:inline-block;padding:6px 10px" href="{{ url_for('dashboard_bp.export_kpis') }}">CSV KPIs</a>
+  <a class="card" style="display:inline-block;padding:6px 10px" href="{{ url_for('dashboard.export_kpis') }}">CSV KPIs</a>
 </form>
 
 <div class="grid">


### PR DESCRIPTION
## Summary
- add reusable `require_login` decorator under `app.security.authz` and expose blueprint guard helpers via `register_login_guard`
- wire the dashboard blueprint to use the new decorator and update package imports, routes, and templates to reflect the `dashboard` namespace
- inject application config into templates, surface the DEV login banner with `config.AUTH_DISABLED`, and ensure the login flow honors the new flag

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e325684a488326954555177c11e2e7