### PR TITLE
Add login smoke test and ensure dashboard redirect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FLASK_ENV: testing
-      SECRET_KEY: dummy
+      SECRET_KEY: dummy-for-ci
       DATABASE_URL: sqlite:///test.db
+      AUTH_DISABLED: "false"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -65,6 +65,8 @@ def _resolve_role(entity: Mapping[str, object] | User | None) -> str:
 def _endpoint_for_role(role: str) -> str:
     view_functions = current_app.view_functions
     if role == "admin":
+        if "dashboard.index" in view_functions:
+            return "dashboard.index"
         return "admin.index"
     if role in {"supervisor", "editor"} and "web.upload" in view_functions:
         return "web.upload"

--- a/tests/test_login_smoke.py
+++ b/tests/test_login_smoke.py
@@ -1,0 +1,47 @@
+def test_login_redirects_to_dashboard(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setenv("SECRET_KEY", "dummy-secret")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("AUTH_DISABLED", "false")
+    monkeypatch.setenv("AUTH_SIMPLE", "false")
+
+    from app import create_app, db
+    from app.models.user import User
+
+    app = create_app()
+    app.config.update(
+        TESTING=True,
+        LOGIN_DISABLED=False,
+        AUTH_SIMPLE=False,
+        WTF_CSRF_ENABLED=False,
+    )
+
+    with app.app_context():
+        db.create_all()
+        user = User(email="admin@admin.com", role="admin", is_active=True)
+        if hasattr(user, "username"):
+            user.username = "admin"
+        if hasattr(user, "status"):
+            user.status = "approved"
+        if hasattr(user, "is_approved"):
+            user.is_approved = True
+        user.set_password("admin123")
+        db.session.add(user)
+        db.session.commit()
+
+        client = app.test_client()
+
+        response_get = client.get("/auth/login")
+        assert response_get.status_code == 200
+
+        response_post = client.post(
+            "/auth/login",
+            data={"email": "admin@admin.com", "password": "admin123"},
+            follow_redirects=False,
+        )
+        assert response_post.status_code in (302, 303)
+        location = response_post.headers.get("Location", "")
+        assert "/dashboard" in location, f"Location={location}"
+
+        response_dashboard = client.get("/dashboard", follow_redirects=True)
+        assert response_dashboard.status_code == 200, response_dashboard.data.decode()[:300]


### PR DESCRIPTION
## Summary
- add a login smoke test that exercises the real authentication flow against an in-memory SQLite database
- route admin users to the dashboard endpoint when it is available so the smoke test follows the expected redirect
- configure the CI workflow to use deterministic authentication settings during the test run

## Testing
- pytest -q --maxfail=1 --disable-warnings

------
https://chatgpt.com/codex/tasks/task_e_68e341dbe2788326869bff2071dc8fb9