### PR TITLE
Simplify login flow and configure login manager

### DIFF
--- a/app/auth/templates/auth/login.html
+++ b/app/auth/templates/auth/login.html
@@ -1,38 +1,10 @@
 {% extends "base.html" %}
 {% block title %}Entrar{% endblock %}
 {% block content %}
-<section class="auth-wrap">
-  <h1>Iniciar sesión</h1>
-  <p class="text-muted">Ingresa tus credenciales. Las cuentas pendientes o rechazadas no pueden acceder.</p>
-  {% if config.AUTH_DISABLED %}
-  <div class="dev-banner">
-    <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
-    <a class="btn" href="{{ url_for('dashboard.index') }}">Ir al Dashboard</a>
-  </div>
-  {% elif DEV_MODE %}
-  <div class="dev-banner">
-    <b>Modo DEV:</b> Autenticación desactivada. Puedes entrar directo al dashboard.
-    <a class="btn" href="{{ url_for('dashboard.index') }}">Ir al Dashboard</a>
-  </div>
-  {% endif %}
-  <form method="POST" action="{{ url_for('auth.login') }}">
-    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <label class="form-label">
-      Correo electrónico
-      <input class="form-control" type="email" name="email" required autofocus autocomplete="email">
-    </label>
-    <label class="form-label">
-      Contraseña
-      <input class="form-control" type="password" name="password" required>
-    </label>
-    <button type="submit">Entrar</button>
-    {% if config.get('ALLOW_SELF_SIGNUP') %}
-      <div class="mt-4 text-center">
-        <a href="{{ url_for('auth.register') }}" class="btn btn-lg btn-outline-primary">
-          ✨ Crear un nuevo usuario
-        </a>
-      </div>
-    {% endif %}
-  </form>
-</section>
+<form method="POST" action="{{ url_for('auth.login') }}" class="auth-login-form">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <input name="email" type="email" placeholder="Correo" required autofocus autocomplete="email" />
+  <input name="password" type="password" placeholder="Contraseña" required autocomplete="current-password" />
+  <button type="submit">Entrar</button>
+</form>
 {% endblock %}

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 from flask_bcrypt import Bcrypt
-from flask_login import LoginManager
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect
 
 bcrypt = Bcrypt()
-login_manager = LoginManager()
-login_manager.login_view = "auth.login"
+login_manager = None
 csrf = CSRFProtect()
 
 # Base de datos


### PR DESCRIPTION
## Summary
- initialize the Flask-Login manager inside the app factory and expose it through the extensions module
- streamline the /auth/login handler to normalize email input, validate hashed passwords, and remember authenticated users
- refresh the login form markup so it posts the required email and password fields expected by the handler

## Testing
- FLASK_APP=app:create_app python - <<'PY'
from app import create_app
app = create_app()
with app.app_context():
    c = app.test_client()
    r = c.post("/auth/login", data={"email":"admin@admin.com","password":"admin123"}, follow_redirects=False)
    print("POST status:", r.status_code, "Location:", r.headers.get("Location"))
    if r.status_code in (302,303):
        rd = c.get(r.headers["Location"])
        print("Dashboard status:", rd.status_code)
    else:
        print("Body:", r.data.decode()[:500])
PY

------
https://chatgpt.com/codex/tasks/task_e_68e37d49faa88326b04cbe7b799d8f93