### PR TITLE
chore: add compat migration 20251015_security_layer

### DIFF
--- a/migrations/versions/20251015_security_layer.py
+++ b/migrations/versions/20251015_security_layer.py
@@ -1,25 +1,25 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = "a20251015_security_layer"
-down_revision = "20251014_alembic_version_64"
+# Este id DEBE ser EXACTAMENTE el que la BD está buscando:
+revision = "20251015_security_layer"
+
+# Sustituye por el id que viste en "alembic heads"
+down_revision = "a20251015_security_layer"
+
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.execute(
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_logins INTEGER DEFAULT 0"
-    )
-    op.execute(
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS lock_until TIMESTAMP NULL"
-    )
-    op.execute(
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(64) NULL"
-    )
+    # Idempotente: sólo añade si faltan (seguro en Postgres)
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_logins INTEGER DEFAULT 0")
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS lock_until TIMESTAMP NULL")
+    op.execute("ALTER TABLE users ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(64) NULL")
 
 
 def downgrade():
+    # Idempotente: sólo elimina si existen
     op.execute("ALTER TABLE users DROP COLUMN IF EXISTS totp_secret")
     op.execute("ALTER TABLE users DROP COLUMN IF EXISTS lock_until")
     op.execute("ALTER TABLE users DROP COLUMN IF EXISTS failed_logins")

--- a/migrations/versions/a20251015_security_layer.py
+++ b/migrations/versions/a20251015_security_layer.py
@@ -1,0 +1,25 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "a20251015_security_layer"
+down_revision = "20251014_alembic_version_64"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS failed_logins INTEGER DEFAULT 0"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS lock_until TIMESTAMP NULL"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(64) NULL"
+    )
+
+
+def downgrade():
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS totp_secret")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS lock_until")
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS failed_logins")


### PR DESCRIPTION
## Summary
- add a compatibility migration 20251015_security_layer that depends on the existing a20251015 revision
- keep the original security layer migration under a revision-aligned filename

## Testing
- alembic -c migrations/alembic.ini upgrade head && FLASK_APP=app:create_app flask seed-admin --email admin@admin.com --password 'admin123' *(fails: SQLite does not support `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` used by existing migration)*

------
https://chatgpt.com/codex/tasks/task_e_68e38a675d4083269fc747edbb47e5fb