### PR TITLE
Make Auth0 optional for CI environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       SECRET_KEY: dummy-for-ci
       DATABASE_URL: sqlite:///test.db
       AUTH_DISABLED: "false"
+      ENABLE_AUTH0: "false"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,6 +24,7 @@ from .extensions import (
     login_manager,
 )
 from .metrics import cleanup_multiprocess_directory
+from .auth0 import init_auth0
 from .utils.scan_lock import get_scan_lock
 from .migrate_ext import init_migrations
 from .security_headers import set_security_headers
@@ -86,6 +87,7 @@ def _normalize_db_url(raw: str | None) -> str:
 
 def create_app(config_name: str | None = None) -> Flask:
     app = Flask(__name__)
+    app.secret_key = os.getenv("SECRET_KEY", "dev-secret")
     raw_uri = os.environ.get("DATABASE_URL", "")
 
     app.config.from_object(get_config())
@@ -285,6 +287,7 @@ def create_app(config_name: str | None = None) -> Flask:
     extensions_db.init_app(app)
     init_migrations(app, extensions_db)
     init_auth_extensions(app)
+    init_auth0(app)
 
     # Crear tablas nuevas automáticamente en DEV (sin molestar a Alembic)
     try:

--- a/app/auth0.py
+++ b/app/auth0.py
@@ -1,0 +1,83 @@
+import os
+from typing import Optional
+
+from flask import Blueprint, current_app, redirect, session
+from authlib.integrations.flask_client import OAuth
+
+bp = Blueprint("auth0", __name__)
+oauth = OAuth()
+
+
+def _is_truthy(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def is_auth0_enabled() -> bool:
+    required_envs = [
+        "AUTH0_DOMAIN",
+        "AUTH0_CLIENT_ID",
+        "AUTH0_CLIENT_SECRET",
+        "AUTH0_CALLBACK_URL",
+    ]
+    if not _is_truthy(os.getenv("ENABLE_AUTH0", "true")):
+        return False
+    return all(os.getenv(name) for name in required_envs)
+
+
+def init_auth0(app) -> None:
+    if not is_auth0_enabled():
+        if bp.name not in app.blueprints:
+            app.register_blueprint(bp)
+        return
+
+    oauth.init_app(app)
+    app.auth0 = oauth.register(
+        "auth0",
+        client_id=os.getenv("AUTH0_CLIENT_ID"),
+        client_secret=os.getenv("AUTH0_CLIENT_SECRET"),
+        client_kwargs={"scope": "openid profile email"},
+        server_metadata_url=f"https://{os.getenv('AUTH0_DOMAIN')}/.well-known/openid-configuration",
+    )
+    if bp.name not in app.blueprints:
+        app.register_blueprint(bp)
+
+
+@bp.get("/login")
+def login():
+    if not is_auth0_enabled():
+        return {"error": "auth_disabled"}, 503
+
+    auth0_client = getattr(current_app, "auth0", None)
+    if auth0_client is None:
+        return {"error": "auth_not_configured"}, 503
+
+    return redirect(
+        auth0_client.authorize_redirect(
+            redirect_uri=os.getenv("AUTH0_CALLBACK_URL")
+        )
+    )
+
+
+@bp.get("/callback")
+def callback():
+    if not is_auth0_enabled():
+        return {"error": "auth_disabled"}, 503
+
+    auth0_client = getattr(current_app, "auth0", None)
+    if auth0_client is None:
+        return {"error": "auth_not_configured"}, 503
+
+    token = auth0_client.authorize_access_token()
+    session["user"] = token.get("userinfo")
+    session["access_token"] = token.get("access_token")
+    return redirect("/")
+
+
+@bp.get("/logout")
+def logout():
+    session.clear()
+    if not is_auth0_enabled():
+        return {"ok": True, "auth": "disabled"}, 200
+    return redirect("/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ Flask-Limiter>=3.7
 pyotp>=2.9
 PyJWT>=2.9.0
 email-validator>=2.2.0
+Authlib>=1.3.2
 
 # Testing
 pytest==8.3.3
@@ -38,3 +39,4 @@ prometheus-client>=0.20.0
 
 # PDF generation
 reportlab>=4.0.0
+requests>=2.32.3


### PR DESCRIPTION
## Summary
- add an Auth0 helper that only registers the real integration when the required environment variables are present
- ensure the Flask app sets a default secret key and wires the optional Auth0 initialization
- declare Authlib/requests dependencies and disable Auth0 in the CI workflow to keep tests passing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5921d8a1c8326a94765ca225cf5cd